### PR TITLE
Modify sysbox packager to incorporate sysbox's new dockerized building process

### DIFF
--- a/deb/Makefile
+++ b/deb/Makefile
@@ -37,7 +37,7 @@ DOCKER_BUILD=docker build                                  \
 	-t debbuild-$@/$(ARCH)                             \
 	-f $(CURDIR)/$@/Dockerfile .
 
-DOCKER_RUN=docker run --rm -i                \
+DOCKER_RUN=docker run --privileged --rm -i       \
 	-e PLATFORM                              \
 	-e VERSION                               \
 	-e COMMIT_ID                             \
@@ -45,6 +45,12 @@ DOCKER_RUN=docker run --rm -i                \
 	-e HOSTNAME                              \
 	-v $(CURDIR)/debbuild/$@:/build          \
 	-v $(GOPATH)/pkg/mod:/go/pkg/mod         \
+	-v $(TEST_VOL1):/var/lib/docker          \
+	-v $(TEST_VOL2):/var/lib/sysbox          \
+	-v $(TEST_VOL3):/mnt/scratch             \
+	-v /lib/modules/$(KERNEL_REL):/lib/modules/$(KERNEL_REL):ro \
+	-v /usr/src/$(HEADERS):/usr/src/$(HEADERS):ro \
+	-v /usr/src/$(HEADERS_BASE):/usr/src/$(HEADERS_BASE):ro \
 	debbuild-$@/$(ARCH)
 
 

--- a/deb/build-deb
+++ b/deb/build-deb
@@ -27,6 +27,11 @@ if [[ ! $? -eq 0 ]]; then
   exit 1
 fi
 
+# Initialize dockerd to allow sysbox's containerized compilation as part of
+# of dpkg-build.
+dockerd > /var/log/dockerd.log 2>&1 &
+sleep 3
+
 # Build the package and copy artifacts to the expected location.
 dpkg-buildpackage -uc -us -I.git
 mkdir -p /build

--- a/deb/common/sysbox.config
+++ b/deb/common/sysbox.config
@@ -29,7 +29,7 @@ fi
 # docker containers during the installation process. Ask user for permission to
 # allow installation process to proceed.
 if [[ ${userns_remap_enabled} = false ]]; then
-    if ! lsmod | grep "${shiftfs_module}" &> /dev/null ; then
+    if ! modprobe "${shiftfs_module}" &> /dev/null ; then
         db_input critical sysbox/docker_autorestart || true
         db_go || true
     fi

--- a/deb/common/sysbox.postinst
+++ b/deb/common/sysbox.postinst
@@ -131,7 +131,7 @@ adjust_docker_config_userns() {
 
     # If 'uid-shifting' mode is not an option, then check user's debconf response
     # to the docker autorestart question.
-    if ! lsmod | grep "${shiftfs_module}" &> /dev/null ; then
+    if ! modprobe "${shiftfs_module}" &> /dev/null ; then
         uid_shift_mode=false
 
         db_get sysbox/docker_autorestart

--- a/deb/ubuntu-bionic/Dockerfile
+++ b/deb/ubuntu-bionic/Dockerfile
@@ -16,19 +16,20 @@ RUN apt-get update &&                            \
     libnet-dev                                   \
     libseccomp2                                  \
     libseccomp-dev                               \
+    iproute2                                     \
     unzip &&                                     \
-                                                 \
+    \
     # Housekeeping
     apt-get clean -y &&                          \
     rm -rf                                       \
-       /var/cache/debconf/*                      \
-       /var/lib/apt/lists/*                      \
-       /var/log/*                                \
-       /tmp/*                                    \
-       /var/tmp/*                                \
-       /usr/share/doc/*                          \
-       /usr/share/man/*                          \
-       /usr/share/local/*
+    /var/cache/debconf/*                      \
+    /var/lib/apt/lists/*                      \
+    /var/log/*                                \
+    /tmp/*                                    \
+    /var/tmp/*                                \
+    /usr/share/doc/*                          \
+    /usr/share/man/*                          \
+    /usr/share/local/*
 
 
 ARG GO_VERSION
@@ -67,6 +68,23 @@ RUN mkdir -p ~/bin/protoc \
     && go get -d -u github.com/golang/protobuf/protoc-gen-go \
     && git -C "$GOPATH"/src/github.com/golang/protobuf checkout $GIT_TAG > /dev/null \
     && go install github.com/golang/protobuf/protoc-gen-go
+
+# install Docker.
+RUN apt-get update \
+    && apt-get install -y \
+    apt-transport-https \
+    ca-certificates \
+    curl \
+    gnupg2 \
+    software-properties-common \
+    && curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add - \
+    && apt-key fingerprint 0EBFCD88 \
+    && add-apt-repository \
+    "deb [arch=amd64] https://download.docker.com/linux/ubuntu \
+    bionic \
+    stable" \
+    && apt-get update && apt-get install -y docker-ce docker-ce-cli containerd.io
+ADD https://raw.githubusercontent.com/docker/docker-ce/master/components/cli/contrib/completion/bash/docker /etc/bash_completion.d/docker.sh
 
 WORKDIR /root/build-deb
 COPY build-deb /root/build-deb/build-deb

--- a/deb/ubuntu-eoan/Dockerfile
+++ b/deb/ubuntu-eoan/Dockerfile
@@ -16,19 +16,20 @@ RUN apt-get update &&                            \
     libnet-dev                                   \
     libseccomp2                                  \
     libseccomp-dev                               \
+    iproute2                                     \
     unzip &&                                     \
-                                                 \
+    \
     # Housekeeping
     apt-get clean -y &&                          \
     rm -rf                                       \
-       /var/cache/debconf/*                      \
-       /var/lib/apt/lists/*                      \
-       /var/log/*                                \
-       /tmp/*                                    \
-       /var/tmp/*                                \
-       /usr/share/doc/*                          \
-       /usr/share/man/*                          \
-       /usr/share/local/*
+    /var/cache/debconf/*                      \
+    /var/lib/apt/lists/*                      \
+    /var/log/*                                \
+    /tmp/*                                    \
+    /var/tmp/*                                \
+    /usr/share/doc/*                          \
+    /usr/share/man/*                          \
+    /usr/share/local/*
 
 ARG GO_VERSION
 ENV GOPATH /go
@@ -66,6 +67,23 @@ RUN mkdir -p ~/bin/protoc \
     && go get -d -u github.com/golang/protobuf/protoc-gen-go \
     && git -C "$GOPATH"/src/github.com/golang/protobuf checkout $GIT_TAG > /dev/null \
     && go install github.com/golang/protobuf/protoc-gen-go
+
+# install Docker.
+RUN apt-get update \
+    && apt-get install -y \
+    apt-transport-https \
+    ca-certificates \
+    curl \
+    gnupg2 \
+    software-properties-common \
+    && curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add - \
+    && apt-key fingerprint 0EBFCD88 \
+    && add-apt-repository \
+    "deb [arch=amd64] https://download.docker.com/linux/ubuntu \
+    eoan \
+    stable" \
+    && apt-get update && apt-get install -y docker-ce docker-ce-cli containerd.io
+ADD https://raw.githubusercontent.com/docker/docker-ce/master/components/cli/contrib/completion/bash/docker /etc/bash_completion.d/docker.sh
 
 WORKDIR /root/build-deb
 COPY build-deb /root/build-deb/build-deb

--- a/deb/ubuntu-focal/Dockerfile
+++ b/deb/ubuntu-focal/Dockerfile
@@ -18,19 +18,20 @@ RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selectio
     libnet-dev                                   \
     libseccomp2                                  \
     libseccomp-dev                               \
+    iproute2                                     \
     unzip &&                                     \
-                                                 \
+    \
     # Housekeeping
     apt-get clean -y &&                          \
     rm -rf                                       \
-       /var/cache/debconf/*                      \
-       /var/lib/apt/lists/*                      \
-       /var/log/*                                \
-       /tmp/*                                    \
-       /var/tmp/*                                \
-       /usr/share/doc/*                          \
-       /usr/share/man/*                          \
-       /usr/share/local/*
+    /var/cache/debconf/*                      \
+    /var/lib/apt/lists/*                      \
+    /var/log/*                                \
+    /tmp/*                                    \
+    /var/tmp/*                                \
+    /usr/share/doc/*                          \
+    /usr/share/man/*                          \
+    /usr/share/local/*
 
 ARG GO_VERSION
 ENV GOPATH /go
@@ -68,6 +69,23 @@ RUN mkdir -p ~/bin/protoc \
     && go get -d -u github.com/golang/protobuf/protoc-gen-go \
     && git -C "$GOPATH"/src/github.com/golang/protobuf checkout $GIT_TAG > /dev/null \
     && go install github.com/golang/protobuf/protoc-gen-go
+
+# install Docker.
+RUN apt-get update \
+    && apt-get install -y \
+    apt-transport-https \
+    ca-certificates \
+    curl \
+    gnupg2 \
+    software-properties-common \
+    && curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add - \
+    && apt-key fingerprint 0EBFCD88 \
+    && add-apt-repository \
+    "deb [arch=amd64] https://download.docker.com/linux/ubuntu \
+    focal \
+    stable" \
+    && apt-get update && apt-get install -y docker-ce docker-ce-cli containerd.io
+ADD https://raw.githubusercontent.com/docker/docker-ce/master/components/cli/contrib/completion/bash/docker /etc/bash_completion.d/docker.sh
 
 WORKDIR /root/build-deb
 COPY build-deb /root/build-deb/build-deb


### PR DESCRIPTION

These changes allow sysbox packager to leverage Sysbox's new building approach, which takes place entirely within our test (priv) container. With these changes now there are two levels of containers launched for each Sysbox package getting built: 1) Basic L1 priv container with docker-daemon and required tools, and then 2) A sysbox-test L2 container under which Sysbox's compilation takes place.

This new approach has a negative impact on Sysbox's package generation interval, which now extends up to 4/5 mins (used to be ~ 1min), due to the need to build the sysbox-test image inside each of the L1 containers that serve as package builders.

Signed-off-by: Rodny Molina <rmolina@nestybox.com>