### PR TITLE
Exclude sysbox-pkgr from being leaked into Sysbox artifacts

### DIFF
--- a/deb/Makefile
+++ b/deb/Makefile
@@ -139,7 +139,7 @@ sources/sysbox.tgz:
 		-v $(SYSBOX_DIR):/sysbox                                 \
 		-v $(CURDIR)/$(@D):/v                                    \
 		alpine                                                   \
-		tar -C / -czf /v/sysbox.tgz --exclude='images' sysbox
+		tar -C / -czf /v/sysbox.tgz --exclude='sysbox-pkgr' sysbox
 
 sources/sysbox.service: ../systemd/sysbox.service
 	mkdir -p $(@D)


### PR DESCRIPTION
Signed-off-by: Rodny Molina <rmolina@nestybox.com>