### PR TITLE
Increase the open file limit for sysbox-fs.

### DIFF
--- a/systemd/sysbox-fs.service
+++ b/systemd/sysbox-fs.service
@@ -12,6 +12,7 @@ TimeoutStopSec=10
 StartLimitInterval=0
 NotifyAccess=main
 OOMScoreAdjust=-500
+LimitNOFILE=32768
 
 [Install]
 WantedBy=sysbox.service


### PR DESCRIPTION
This is needed for scenarios where hundreds of containers are deployed
with Sysbox on the same host. The default Linux limit of 4096 can
be exceeded in such cases.

Sysbox-fs opens files for many reasons: for communication with
other sysbox components, when processing syscalls, when processing
FUSE accesses, for logging, etc. When processing syscalls and
FUSE accesses, the number of open files is a function of the
number of processes doing those accesses. This is why a high
limit on open-files is required.

Signed-off-by: Cesar Talledo <ctalledo@nestybox.com>