### PR TITLE
Set sysbox-fs and sysbox-mgr file and process limit to "unlimited" in systemd service files.

### DIFF
--- a/systemd/sysbox-fs.service
+++ b/systemd/sysbox-fs.service
@@ -12,7 +12,12 @@ TimeoutStopSec=10
 StartLimitInterval=0
 NotifyAccess=main
 OOMScoreAdjust=-500
-LimitNOFILE=32768
+
+# The number of files opened by sysbox-fs is a function of the number of
+# containers and the workloads within them. Thus we set the limit to
+# infinite so to prevent "too many open files" errors.
+LimitNOFILE=infinity
+LimitNPROC=infinity
 
 [Install]
 WantedBy=sysbox.service

--- a/systemd/sysbox-mgr.service
+++ b/systemd/sysbox-mgr.service
@@ -12,5 +12,11 @@ StartLimitInterval=0
 NotifyAccess=main
 OOMScoreAdjust=-500
 
+# The number of files opened by sysbox-mgr is a function of the number of
+# containers and the size of the rootfs within them. Thus we set the limit to
+# infinite so to prevent "too many open files" errors.
+LimitNOFILE=infinity
+LimitNPROC=infinity
+
 [Install]
 WantedBy=sysbox.service


### PR DESCRIPTION
For sysbox-fs, this is necessary because the number of file descriptors it opens
is a function of the number of containers in the system multiplied by the number
of accesses that processes in those containers perform on resources trapped by
sysbox-fs (e.g., /proc/sys/*, trapped syscalls, /sys/*, etc.)

For sysbox-mgr this is necessary because the number of file descriptors it opens
is also a function of the number of containers in the system multiplied by the
how many files within those containers require copy to/from /var/lib/sysbox
(e.g., sysbox containers that include inner container images for example).  The
copy operation is done by rsync, and this can potentially open many file
descriptors.

Instead of setting an artificial limit which we can't predict, we instead
tell systemd to place no limit. Note that Docker takes a similar approach
in its systemd service file.

Note that this fixex Sysbox issue 195.

Signed-off-by: Cesar Talledo <ctalledo@nestybox.com>