### PR TITLE
Workaround old Makefile issue

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,11 @@ ARCH=$(shell uname -m)
 		clean-ce-deb        \
 		clean-ce-rpm        \
 		clean-ee-deb        \
-		clean-ee-rpm
+		clean-ee-rpm        \
+		ubuntu-bionic       \
+		ubuntu-focal        \
+		debian-buster       \
+		debian-bullseye
 
 
 # CE & EE git repository structures.
@@ -98,21 +102,21 @@ sysbox-ee-rpm: $(EE_SOURCES) clean-ee-rpm
 sysbox-ce-repo: ## Set path to the sysbox-ce repo (remote github repo by default)
 sysbox-ce-repo:
 	$(eval REPO_PATH=$(filter-out sysbox-ce-repo $@,$(MAKECMDGOALS)))
-	printf "\n*** Setting sysbox-ce repository path to $(REPO_PATH) ***\n\n"
+	@printf "\n*** Setting sysbox-ce repository path to $(REPO_PATH) ***\n\n"
 	@ln -sf $(REPO_PATH) $(CE_SOURCES)
 
 sysbox-ee-repo: ## Set path to the sysbox-ee repo (remote github repo by default)
 sysbox-ee-repo:
 	$(eval REPO_PATH=$(filter-out sysbox-ee-repo $@,$(MAKECMDGOALS)))
-	printf "\n*** Setting sysbox-ee repository path to $(REPO_PATH) ***\n\n"
+	@printf "\n*** Setting sysbox-ee repository path to $(REPO_PATH) ***\n\n"
 	@ln -sf $(REPO_PATH) $(EE_SOURCES)
 
 sources/sysbox:
-	printf "\n*** Cloning sysbox-ce superproject repository to $(CE_SOURCES) ***\n\n"
+	@printf "\n*** Cloning sysbox-ce superproject repository to $(CE_SOURCES) ***\n\n"
 	@git clone --recursive git@github.com:nestybox/sysbox.git sources/sysbox
 
 sources/sysbox-internal:
-	printf "\n*** Cloning sysbox-ee superproject repository to $(EE_SOURCES) ***\n\n"
+	@printf "\n*** Cloning sysbox-ee superproject repository to $(EE_SOURCES) ***\n\n"
 	@git clone --recursive git@github.com:nestybox/sysbox-internal.git sources/sysbox-internal
 
 


### PR DESCRIPTION
I'm ashamed to admit that I haven't found a solution for this one since the first time i reproduced it more than a year ago :-(

Problem seems to be related to the recursive layout in which Makefiles are placed in this module. Problem is reproduced by executing a target in the top-most Makefile, that in turn has a dependency on an inner folder. In the output displayed below, i've commented out the main Makefile instruction to focus on the initialization and finalization of the target execution.

Notice that the actions associated to the inner target are properly executed, but error is observed when returning back to the outer Makefile.

```
rmolina@dev-vm1:~/wsp/03-30-2021/sysbox-internal/sysbox-pkgr$ make sysbox-ee-deb ubuntu-focal
make -C deb --no-print-directory clean
make: *** No rule to make target 'ubuntu-focal'.  Stop.
```

For some reason that i'm yet to understand, problem can be workaround'ed by exposing the targets in the inner folders as 'phony' targets in the outer Makefile..

Signed-off-by: Rodny Molina <rmolina@nestybox.com>