### PR TITLE
Modify sysbox package to have sysbox send logs to the systemd log.

### DIFF
--- a/systemd/sysbox-fs.service
+++ b/systemd/sysbox-fs.service
@@ -6,7 +6,7 @@ After=sysbox-mgr.service
 [Service]
 Type=simple
 Type=notify
-ExecStart=/usr/local/sbin/sysbox-fs --log /var/log/sysbox-fs.log
+ExecStart=/usr/local/sbin/sysbox-fs
 TimeoutStartSec=10
 TimeoutStopSec=10
 StartLimitInterval=0

--- a/systemd/sysbox-mgr.service
+++ b/systemd/sysbox-mgr.service
@@ -5,7 +5,7 @@ PartOf=sysbox.service
 [Service]
 Type=simple
 Type=notify
-ExecStart=/usr/local/sbin/sysbox-mgr --log /var/log/sysbox-mgr.log
+ExecStart=/usr/local/sbin/sysbox-mgr
 TimeoutStartSec=45
 TimeoutStopSec=90
 StartLimitInterval=0


### PR DESCRIPTION
Recent changes in sysbox-mgr and sysbox-fs enable them to log
to the systemd journal log (by virtue of logging on stderr
by default). This is advantageous as we don't have to worry
about log size or log rotation (systemd takes care of that).

In this change, we modify the systemd unit files for
sysbox-mgr and sysbox-fs such that they will no longer
log to the "/var/log/sysbox-*" files and instead logs
will now go to the systemd journal log.

Signed-off-by: Cesar Talledo <ctalledo@nestybox.com>