### PR TITLE
Replace old sysbox-runc bin location in Docker config.

### DIFF
--- a/deb/sysbox-ce/sysbox-ce.postinst
+++ b/deb/sysbox-ce/sysbox-ce.postinst
@@ -215,14 +215,19 @@ function adjust_docker_config_runtime() {
         docker_runtime_config_changed="true"
 
     # If the runtime config is complete (i.e. both 'runtimes' and 'sysbox-runc'
-    # entries exist), but this state has not been digested by docker yet, ensure
-    # that docker processes it before this installation concludes.
-    elif [ $(jq 'has("runtimes")' ${dockerCfgFile}) = "true" ] &&
-         [ $(jq '.runtimes | has("sysbox-runc")' ${dockerCfgFile}) = true ] &&
-         command -v docker >/dev/null 2>&1 &&
-         ! docker info 2>&1 | egrep -q "Runtimes:.*sysbox-runc"; then
+    # entries exist) but has the old sysbox-runc binary location, update the location.
+    elif grep -q "/usr/local/sbin/sysbox-runc" ${dockerCfgFile}; then
+       sed -i "s@/usr/local/sbin/sysbox-runc@/usr/bin/sysbox-runc@g" ${dockerCfgFile}
+       docker_runtime_config_changed="true"
+    fi
 
-        docker_runtime_config_changed="true"
+    # If the state has not been digested by docker yet, ensure that docker
+    # processes it before this installation concludes.
+    if [ ${docker_runtime_config_changed} = false ] &&
+          command -v docker >/dev/null 2>&1 &&
+          ! docker info 2>&1 | egrep -q "Runtimes:.*sysbox-runc"; then
+
+       docker_runtime_config_changed="true"
     fi
 }
 

--- a/deb/sysbox-ee/sysbox-ee.postinst
+++ b/deb/sysbox-ee/sysbox-ee.postinst
@@ -215,14 +215,19 @@ function adjust_docker_config_runtime() {
         docker_runtime_config_changed="true"
 
     # If the runtime config is complete (i.e. both 'runtimes' and 'sysbox-runc'
-    # entries exist), but this state has not been digested by docker yet, ensure
-    # that docker processes it before this installation concludes.
-    elif [ $(jq 'has("runtimes")' ${dockerCfgFile}) = "true" ] &&
-         [ $(jq '.runtimes | has("sysbox-runc")' ${dockerCfgFile}) = true ] &&
-         command -v docker >/dev/null 2>&1 &&
-         ! docker info 2>&1 | egrep -q "Runtimes:.*sysbox-runc"; then
+    # entries exist) but has the old sysbox-runc binary location, update the location.
+    elif grep -q "/usr/local/sbin/sysbox-runc" ${dockerCfgFile}; then
+       sed -i "s@/usr/local/sbin/sysbox-runc@/usr/bin/sysbox-runc@g" ${dockerCfgFile}
+       docker_runtime_config_changed="true"
+    fi
 
-        docker_runtime_config_changed="true"
+    # If the state has not been digested by docker yet, ensure that docker
+    # processes it before this installation concludes.
+    if [ ${docker_runtime_config_changed} = false ] &&
+          command -v docker >/dev/null 2>&1 &&
+          ! docker info 2>&1 | egrep -q "Runtimes:.*sysbox-runc"; then
+
+       docker_runtime_config_changed="true"
     fi
 }
 


### PR DESCRIPTION
This change improves the sysbox package installer by having it check if the
Docker daemon config file (/etc/docker/daemon.json) has an outdated
config for the sysbox-runc binary location, and replacing it with the
new sysbox-runc binary location.

The situation where this check kicks in would normally not occur
since the Sysbox package uninstaller removes the sysbox-runc config
from /etc/docker/daemon.json, but nonetheless this change makes
the package installer more robust.

Signed-off-by: Cesar Talledo <ctalledo@nestybox.com>