### PR TITLE
Extend gha matric to debian-bullseye and reduce number of parallel jobs

### DIFF
--- a/.github/workflows/sysbox-ce-pkg-ci.yml
+++ b/.github/workflows/sysbox-ce-pkg-ci.yml
@@ -18,8 +18,9 @@ jobs:
     runs-on: [self-hosted, Linux, X64, '${{ matrix.distro }}']
     strategy:
       fail-fast: false
+      max-parallel: 2
       matrix:
-        distro: [ubuntu-bionic, ubuntu-focal, debian-buster]
+        distro: [ubuntu-bionic, ubuntu-focal, debian-buster, debian-bullseye]
     steps:
       - name: precheckout-cleanup
         run: |

--- a/.github/workflows/sysbox-ee-pkg-ci.yml
+++ b/.github/workflows/sysbox-ee-pkg-ci.yml
@@ -18,8 +18,9 @@ jobs:
     runs-on: [self-hosted, Linux, X64, '${{ matrix.distro }}']
     strategy:
       fail-fast: false
+      max-parallel: 2
       matrix:
-        distro: [ubuntu-bionic, ubuntu-focal, debian-buster]
+        distro: [ubuntu-bionic, ubuntu-focal, debian-buster, debian-bullseye]
     steps:
       - name: precheckout-cleanup
         run: |


### PR DESCRIPTION
* We can now activate Debian Bullseye job as cgroup-v2 feature is already implemented.
* By reducing the number of parallel jobs (no more than two matrix-elements at a time), we hope to gain more stability in our CI pipeline, which is suffering from too many network-related issues.

Signed-off-by: Rodny Molina <rmolina@nestybox.com>