### PR TITLE
Fix building issue preventing debian-buster image from being generated

### DIFF
--- a/deb/sysbox-ce/rules
+++ b/deb/sysbox-ce/rules
@@ -10,6 +10,9 @@ override_dh_auto_build:
 
 override_dh_auto_test:
 
+# Override dwz to avoid issues in debian-buster with debhelper=12 compat.
+override_dh_dwz:
+
 # ONESHELL attribute to ensure that all instruccions in this target are executed
 # within a single shell process.
 .ONESHELL:

--- a/deb/sysbox-ee/rules
+++ b/deb/sysbox-ee/rules
@@ -10,6 +10,9 @@ override_dh_auto_build:
 
 override_dh_auto_test:
 
+# Override dwz to avoid issues in debian-buster with debhelper=12 compat.
+override_dh_dwz:
+
 # ONESHELL attribute to ensure that all instruccions in this target are executed
 # within a single shell process.
 .ONESHELL:


### PR DESCRIPTION
Problem seems to be related to an incompatibility issue between 'dwz' module and 'debhelper' when operating at compat=12 level. This is the error generated by my debian-buster VM when i try to build a Sysbox image:

```
   dh_missing
   dh_dwz
	install -d debian/sysbox-ce/usr/lib/debug/.dwz/x86_64-linux-gnu
	dwz -q -mdebian/sysbox-ce/usr/lib/debug/.dwz/x86_64-linux-gnu/sysbox-ce.debug -M/usr/lib/debug/.dwz/x86_64-linux-gnu/sysbox-ce.debug -- debian/sysbox-ce/usr/bin/sysbox-fs debian/sysbox-ce/usr/bin/sysbox-mgr debian/sysbox-ce/usr/bin/sysbox-runc
dwz: Too few files for multifile optimization
	objcopy --compress-debug-sections debian/sysbox-ce/usr/lib/debug/.dwz/x86_64-linux-gnu/sysbox-ce.debug
objcopy: 'debian/sysbox-ce/usr/lib/debug/.dwz/x86_64-linux-gnu/sysbox-ce.debug': No such file
dh_dwz: objcopy --compress-debug-sections debian/sysbox-ce/usr/lib/debug/.dwz/x86_64-linux-gnu/sysbox-ce.debug returned exit code 1
make: *** [debian/rules:62: binary] Error 2
dpkg-buildpackage: error: debian/rules binary subprocess returned exit status 2
make[1]: *** [Makefile:93: debian-buster] Error 2
make: *** [Makefile:85: sysbox-ce-deb] Error 2
```

Based on the info that i've found online (example below), there seems to be some issues with compat=12 and dwz, so for now i'm skipping dwz functionality, which doesn't really makes much of a difference for Sysbox binaries anyways.

* https://www.mail-archive.com/debian-bugs-dist@lists.debian.org/msg1691470.html

Signed-off-by: Rodny Molina <rmolina@nestybox.com>