### PR TITLE
Increase keyring maxbytes config to 1.4MB (70 bytes per key).

### DIFF
--- a/systemd/99-sysbox-sysctl.conf
+++ b/systemd/99-sysbox-sysctl.conf
@@ -19,10 +19,9 @@ fs.inotify.max_user_instances = 1048576
 #
 # That is, a 10-node cluster would need 282 keys.
 #
-# In a large bare-metal machine, we expect ~100 sys containers. That
-# would consume ~11K keys.  To be conservative, we set maxkeys to
-# 20K. Note that since each key consumes 20KB, the total mem
-# consumption assuming all 20K keys are used is 400MB.
-# In addition, maxbytes = 20 bytes * maxkeys.
+# In a large bare-metal machine, we expect ~100 sys containers. That would
+# consume ~11K keys.  To be conservative, we set maxkeys to 20K. Note that since
+# each key consumes ~70 bytes on average, the total mem consumption assuming all
+# 20K keys are used is 20K * 70 = 1.4MB.
 kernel.keys.maxkeys = 20000
-kernel.keys.maxbytes = 400000
+kernel.keys.maxbytes = 1400000


### PR DESCRIPTION
We originally assumed each key would consume 20 bytes on average, but this seems
too conservative as deploying a simple Alpine-based container with Sysbox uses a
70 byte key. This change corrects this.

Signed-off-by: Cesar Talledo <ctalledo@nestybox.com>