### PR TITLE
[k8s] Fix for kubelet-snap setup (EKS) being unable to come up during installation

### DIFF
--- a/k8s/scripts/kubelet-config-helper.sh
+++ b/k8s/scripts/kubelet-config-helper.sh
@@ -752,8 +752,8 @@ function clean_runtime_state() {
 # Scenario 1: Snap setup -- Snap-based kubelet
 ###############################################################################
 
-function restart_kubelet_snap() {
-	snap restart $kubelet_snap
+function start_kubelet_snap() {
+	snap start $kubelet_snap
 }
 
 function stop_kubelet_snap() {
@@ -794,13 +794,13 @@ function do_config_kubelet_snap() {
 		stop_kubelet_snap
 		clean_runtime_state "$runtime"
 		config_kubelet_snap
-		restart_kubelet_snap
+		start_kubelet_snap
 	else
 		stop_kubelet_snap
 		clean_runtime_state "$runtime"
 		stop_containerd
 		config_kubelet_snap
-		restart_kubelet_snap
+		start_kubelet_snap
 	fi
 }
 


### PR DESCRIPTION
Once that the kubelet-eks snap service is stopped, the 'restart' instruction doesn't really bring the kubelet-eks service up. There are two potential solutions to have the kubelet service being restored::

1) 'snap restart kubelet-eks.daemon' or ...
2) 'snap start kubelet-eks'

As the rest of the code is already using 'kubelet-eks' and it wouldn't work with the 'kubelet-eks.daemon' option, we go for option 1) here.

```
ubuntu@ip-192-168-58-118:~$ sudo snap stop kubelet-eks
Stopped.

ubuntu@ip-192-168-58-118:~$ sudo snap services kubelet-eks
Service             Startup  Current   Notes
kubelet-eks.daemon  enabled  inactive  -

<-- This 'restart' doesn't do anything in reality ...

ubuntu@ip-192-168-58-118:~$ sudo snap restart kubelet-eks
Restarted.

<-- This 'start' brings the service up ...

ubuntu@ip-192-168-58-118:~$ sudo snap start kubelet-eks
Started.
```

Signed-off-by: Rodny Molina <rmolina@nestybox.com>