### PR TITLE
Fix 'shiftfs' warning and relax 'configfs' requirement

### DIFF
--- a/deb/sysbox-ce/sysbox-ce.config
+++ b/deb/sysbox-ce/sysbox-ce.config
@@ -86,7 +86,6 @@ function shiftfs_module_present() {
 function docker_restart_required() {
 
     docker_userns_remap_mode
-    shiftfs_module_present
     docker_network_valid_config
 
     # There are only two scenarios for which dockerd would not need to be restarted:
@@ -120,28 +119,30 @@ function docker_restart_required() {
 # Checks if the docker engine is installed on the host
 #
 function docker_installed() {
-	ret=$(command -v dockerd >/dev/null 2>&1)
-	return $?
+    ret=$(command -v dockerd >/dev/null 2>&1)
+    return $?
 }
 
 #
 # Checks if the docker engine is running on the host
 #
 function docker_running() {
-	ret=$(pidof dockerd > /dev/null 2>&1)
-	return $?
+    ret=$(pidof dockerd >/dev/null 2>&1)
+    return $?
 }
 
 #
 # Main
 #
 
+shiftfs_module_present
+
 # If a docker-restart is required in this setup, and there are existing containers,
 # alert user of the need to stop containers and exit installation process.
 if docker_running && docker_restart_required && docker_existing_containers; then
-    echo -e "\nSysbox installer found existing Docker containers. Please remove"\
-            "them as indicated below. Refer to Sysbox installation documentation for details.\n"\
-            "\t\"docker rm \$(docker ps -a -q) -f\"\n"
+    echo -e "\nSysbox installer found existing Docker containers. Please remove" \
+        "them as indicated below. Refer to Sysbox installation documentation for details.\n" \
+        "\t\"docker rm \$(docker ps -a -q) -f\"\n"
     exit 1
 fi
 
@@ -150,17 +151,17 @@ fi
 # allow installation process to proceed.
 if [ ${shiftfs_module_on} = "false" ]; then
 
-    echo -e "\nYour OS does not include the shiftfs module. Make sure to configure"\
-			"the container manager (e.g., Docker, CRI-O, etc) to use the Linux user-namespace"\
-			"when creating containers with Sysbox. Refer to Sysbox installation documentation"\
-			"for details.\n"
+    echo -e "\nYour OS does not include the shiftfs module. Make sure to configure" \
+        "the container manager (e.g., Docker, CRI-O, etc) to use the Linux user-namespace" \
+        "when creating containers with Sysbox. Refer to Sysbox installation documentation" \
+        "for details.\n"
 
-	 if docker_installed; then
-		 if [ ${userns_remap_on} = "false" ]; then
-			 db_input critical sysbox/docker_userns_remap_autoconfig || true
-			 db_go || true
-		 fi
-	 fi
+    if docker_installed; then
+        if [ ${userns_remap_on} = "false" ]; then
+            db_input critical sysbox/docker_userns_remap_autoconfig || true
+            db_go || true
+        fi
+    fi
 fi
 
 #DEBHELPER#

--- a/deb/sysbox-ce/sysbox-ce.postinst
+++ b/deb/sysbox-ce/sysbox-ce.postinst
@@ -78,11 +78,10 @@ function enable_unprivileged_userns() {
 # Ensures that 'configfs' module is properly loaded.
 function check_configfs_loaded() {
 
-    # Return error if configfs module is not present or can't be loaded.
-    if ! modprobe "${configfs_module}" &> /dev/null ; then
-        echo -e "\nConfigfs kernel module could not be loaded. Configfs may be required"\
-                "by certain applications running inside a Sysbox container.\n"
-        exit 1
+    # Print a warning if configfs module is not present or can't be loaded.
+    if ! modprobe "${configfs_module}" &>/dev/null; then
+        echo -e "\nConfigfs kernel module could not be loaded. Configfs may be required" \
+            "by certain applications running inside a Sysbox container.\n"
     fi
 }
 

--- a/deb/sysbox-ee/sysbox-ee.config
+++ b/deb/sysbox-ee/sysbox-ee.config
@@ -86,7 +86,6 @@ function shiftfs_module_present() {
 function docker_restart_required() {
 
     docker_userns_remap_mode
-    shiftfs_module_present
     docker_network_valid_config
 
     # There are only two scenarios for which dockerd would not need to be restarted:
@@ -120,28 +119,30 @@ function docker_restart_required() {
 # Checks if the docker engine is installed on the host
 #
 function docker_installed() {
-	ret=$(command -v dockerd >/dev/null 2>&1)
-	return $?
+    ret=$(command -v dockerd >/dev/null 2>&1)
+    return $?
 }
 
 #
 # Checks if the docker engine is running on the host
 #
 function docker_running() {
-	ret=$(pidof dockerd > /dev/null 2>&1)
-	return $?
+    ret=$(pidof dockerd >/dev/null 2>&1)
+    return $?
 }
 
 #
 # Main
 #
 
+shiftfs_module_present
+
 # If a docker-restart is required in this setup, and there are existing containers,
 # alert user of the need to stop containers and exit installation process.
 if docker_running && docker_restart_required && docker_existing_containers; then
-    echo -e "\nSysbox installer found existing Docker containers. Please remove"\
-            "them as indicated below. Refer to Sysbox installation documentation for details.\n"\
-            "\t\"docker rm \$(docker ps -a -q) -f\"\n"
+    echo -e "\nSysbox installer found existing Docker containers. Please remove" \
+        "them as indicated below. Refer to Sysbox installation documentation for details.\n" \
+        "\t\"docker rm \$(docker ps -a -q) -f\"\n"
     exit 1
 fi
 
@@ -150,17 +151,17 @@ fi
 # allow installation process to proceed.
 if [ ${shiftfs_module_on} = "false" ]; then
 
-    echo -e "\nYour OS does not include the shiftfs module. Make sure to configure"\
-			"the container manager (e.g., Docker, CRI-O, etc) to use the Linux user-namespace"\
-			"when creating containers with Sysbox. Refer to Sysbox installation documentation"\
-			"for details.\n"
+    echo -e "\nYour OS does not include the shiftfs module. Make sure to configure" \
+        "the container manager (e.g., Docker, CRI-O, etc) to use the Linux user-namespace" \
+        "when creating containers with Sysbox. Refer to Sysbox installation documentation" \
+        "for details.\n"
 
-	 if docker_installed; then
-		 if [ ${userns_remap_on} = "false" ]; then
-			 db_input critical sysbox/docker_userns_remap_autoconfig || true
-			 db_go || true
-		 fi
-	 fi
+    if docker_installed; then
+        if [ ${userns_remap_on} = "false" ]; then
+            db_input critical sysbox/docker_userns_remap_autoconfig || true
+            db_go || true
+        fi
+    fi
 fi
 
 #DEBHELPER#

--- a/deb/sysbox-ee/sysbox-ee.postinst
+++ b/deb/sysbox-ee/sysbox-ee.postinst
@@ -78,11 +78,10 @@ function enable_unprivileged_userns() {
 # Ensures that 'configfs' module is properly loaded.
 function check_configfs_loaded() {
 
-    # Return error if configfs module is not present or can't be loaded.
-    if ! modprobe "${configfs_module}" &> /dev/null ; then
-        echo -e "\nConfigfs kernel module could not be loaded. Configfs may be required"\
-                "by certain applications running inside a Sysbox container.\n"
-        exit 1
+    # Print a warning if configfs module is not present or can't be loaded.
+    if ! modprobe "${configfs_module}" &>/dev/null; then
+        echo -e "\nConfigfs kernel module could not be loaded. Configfs may be required" \
+            "by certain applications running inside a Sysbox container.\n"
     fi
 }
 


### PR DESCRIPTION
Addresses Block's (Square) issue with 'configfs' being an unmet requirement. Also fixes a bug in which Sysbox installer generates a 'shiftfs' warning message even when the corresponding kernel module is present in the system.

Signed-off-by: Rodny Molina <rmolina@nestybox.com>