### PR TITLE
[k8s] Disable 'selinux' on crio config (on by default)

### DIFF
--- a/k8s/scripts/sysbox-deploy-k8s.sh
+++ b/k8s/scripts/sysbox-deploy-k8s.sh
@@ -196,6 +196,9 @@ function config_crio() {
 	dasel put string -f ${host_crio_conf_file} -p toml "crio.runtime.cgroup_manager" "cgroupfs"
 	dasel put string -f ${host_crio_conf_file} -p toml "crio.runtime.conmon_cgroup" "pod"
 
+	# Disable selinux for now.
+	dasel put bool -f ${host_crio_conf_file} -p toml -m "crio.runtime.selinux" false
+
 	# In GKE, the CNIs are not in the usual "/opt/cni/bin/" dir, but under "/home/kubernetes/bin"
 	dasel put string -f ${host_crio_conf_file} -p toml -m 'crio.network.plugin_dirs.[]' "/opt/cni/bin"
 	dasel put string -f ${host_crio_conf_file} -p toml -m 'crio.network.plugin_dirs.[]' "/home/kubernetes/bin"


### PR DESCRIPTION
This seems to be causing issues in GR deployment. It's interesting that this was not affecting GR before, which can be only explained by cri-o switching the default selinux operational mode when moving from cri-0 1.20 to 1.21.

Signed-off-by: Rodny Molina <rmolina@nestybox.com>