### PR TITLE
Fix bug with sysbox's config installation script

### DIFF
--- a/deb/sysbox-ce/sysbox-ce.config
+++ b/deb/sysbox-ce/sysbox-ce.config
@@ -25,10 +25,10 @@ function docker_network_valid_config() {
     if [[ -f ${dockerCfgFile} ]] &&
         egrep -q "^[ ]+\"bip\": \"[0-9.]+.*\"" ${dockerCfgFile} &&
         egrep -q "^[ ]+\"default-address-pools\"" ${dockerCfgFile}; then
-        return 1
+        return 0
     fi
 
-    return 0
+    return 1
 }
 
 #

--- a/deb/sysbox-ee/sysbox-ee.config
+++ b/deb/sysbox-ee/sysbox-ee.config
@@ -25,10 +25,10 @@ function docker_network_valid_config() {
     if [[ -f ${dockerCfgFile} ]] &&
         egrep -q "^[ ]+\"bip\": \"[0-9.]+.*\"" ${dockerCfgFile} &&
         egrep -q "^[ ]+\"default-address-pools\"" ${dockerCfgFile}; then
-        return 1
+        return 0
     fi
 
-    return 0
+    return 1
 }
 
 #


### PR DESCRIPTION
Silly bug that reverts the logic and skips user notifications when containers are around during installation.

Signed-off-by: Rodny Molina <rmolina@nestybox.com>