### PR TITLE
[k8s] Fix issue preventing snap-based kubelet deployments from being properly configured

### DIFF
--- a/k8s/scripts/kubelet-config-helper.sh
+++ b/k8s/scripts/kubelet-config-helper.sh
@@ -660,8 +660,9 @@ function adjust_crio_config_dependencies() {
 	local pause_image
 	if [ ! -z "$pause_image_systemd" ]; then
 		pause_image=$pause_image_systemd
-	elif [ ! -z "$pause_image_snap" ]; then
-		pause_image=$pause_image_snap
+	# Skipping for now due to issue #550.
+	# elif [ ! -z "$pause_image_snap" ]; then
+	#	pause_image=$pause_image_snap
 	fi
 
 	if [ ! -z "$pause_image" ]; then


### PR DESCRIPTION
The current crio-configuration logic was not taking into account kubelet's config dependencies in snap-based setups (e.g., eksctl created clusters).

Signed-off-by: Rodny Molina <rmolina@nestybox.com>