### PR TITLE
Build CRI-O inside a container.

### DIFF
--- a/k8s/Dockerfile.crio
+++ b/k8s/Dockerfile.crio
@@ -1,0 +1,43 @@
+#
+# CRI-O build container Dockerfile
+#
+
+FROM ubuntu:impish
+
+# K8s version for k8s-in-docker (i.e., this is the version of K8s running inside
+# the k8s-in-docker container).
+ARG k8s_version=v1.20.2
+
+# CRI-O & crictl version for testing sysbox pods; CRI-O 1.20 is required as it
+# introduces rootless pod support (via the Linux user-ns)
+ARG crio_version=1.20
+ARG crio_os=xUbuntu_20.04
+ARG crictl_version=v1.20.0
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    git \
+    make \
+    wget \
+    ca-certificates \
+    ssh-client \
+    gcc \
+    libgpgme-dev
+
+# Install Golang 1.16.4 release and explicitly activate modules functionality.
+RUN wget https://golang.org/dl/go1.17.5.linux-amd64.tar.gz && \
+    tar -C /usr/local -xzf go1.17.5.linux-amd64.tar.gz && \
+    /usr/local/go/bin/go env -w GONOSUMDB=/root/nestybox
+
+ENV GOPATH /go
+ENV PATH $GOPATH/bin:/usr/local/go/bin:$PATH
+RUN go env -w GONOSUMDB=/root/nestybox && \
+    mkdir -p "$GOPATH/src" "$GOPATH/bin" && \
+    chmod -R 777 "$GOPATH"
+
+# CRI-O build script
+COPY scripts/crio-build.sh /usr/bin/crio-build.sh
+
+WORKDIR /root
+CMD crio-build.sh

--- a/k8s/Makefile
+++ b/k8s/Makefile
@@ -19,7 +19,6 @@ SHELL := /bin/bash
 SYSBOX_BINS = sysbox-runc sysbox-mgr sysbox-fs
 SYSBOX_FLATCAR_BINS = $(SYSBOX_BINS) fusermount shiftfs.ko
 SYSBOX_VER = 0.5.1
-CRIO_VERSIONS = v1.20 v1.21 v1.22 v1.23
 
 # Supported Flatcar versions
 FLATCAR_VERSIONS := 2905.2.3 2905.2.6 3033.2.4
@@ -142,18 +141,12 @@ $(FLATCAR_DEV_ENVS):
 # $ sudo apt-get install -y libgpgme-dev
 #
 
-build-crio: $(CRIO_VERSIONS)
+build-crio: crio-build-container bin/crio
+	docker run -v $(shell pwd)/bin:/mnt/results crio-bld
 
-$(CRIO_VERSIONS):
-	@printf "\n*** Building cri-o $@ ... ***\n\n"
-	$(eval TMPDIR := $(shell mktemp -d))
-	@chmod 755 $(TMPDIR)
-	@git clone git@github.com:nestybox/cri-o.git $(TMPDIR)/cri-o
-	@git -C $(TMPDIR)/cri-o checkout -b $@-sysbox origin/$@-sysbox
-	@cd $(TMPDIR)/cri-o && make binaries
-	@mkdir -p bin/crio/$@
-	@cp $(TMPDIR)/cri-o/bin/crio-static bin/crio/$@/crio
-	@chmod 755 -R $(TMPDIR) && rm -rf $(TMPDIR)
+
+crio-build-container:
+	docker build -t crio-bld -f Dockerfile.crio .
 
 #
 # The check-* targets verify that CRI-O, Sysbox binaries and its dependencies are

--- a/k8s/scripts/crio-build.sh
+++ b/k8s/scripts/crio-build.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+#
+# CRI-O build script (meant to run inside the CRI-O build container)
+#
+# The script will build the Nestybox-customized CRI-O and place the binaries
+# under /mnt/results. It builds several versions of CRI-O.
+#
+# Usage: docker run -v $(shell pwd)/bin:/mnt/results crio-bld
+#
+
+declare -a CRIO_VERSIONS=(v1.20 v1.21 v1.22 v1.23)
+
+for ver in ${CRIO_VERSIONS[@]}; do
+	printf "\n*** Building CRI-O ${ver} ... ***\n\n"
+	TMPDIR=$(mktemp -d)
+	chmod 755 ${TMPDIR}
+	git clone https://github.com/nestybox/cri-o.git ${TMPDIR}/cri-o
+	git -C ${TMPDIR}/cri-o checkout -b ${ver}-sysbox origin/${ver}-sysbox
+	cd ${TMPDIR}/cri-o && make binaries
+	mkdir -p /mnt/results/bin/crio/${ver}
+	cp ${TMPDIR}/cri-o/bin/crio-static /mnt/results/crio/${ver}/crio
+done


### PR DESCRIPTION
Prior to this change, the sysbox-deploy-k8s Makefile was building the
customized CRI-O at host level. This caused problems as the build
was not working properly on some hosts.

This change builds CRI-O inside a container for more consistency.

Signed-off-by: Cesar Talledo <ctalledo@nestybox.com>