### PR TITLE
sysbox-deploy-k8s: support shiftfs on Linux kernels up to 5.18

### DIFF
--- a/k8s/Dockerfile.sysbox-ce
+++ b/k8s/Dockerfile.sysbox-ce
@@ -47,7 +47,10 @@ RUN wget https://github.com/kubernetes-sigs/cri-tools/releases/download/${CRICTL
 RUN git clone --branch k5.4 https://github.com/nestybox/shiftfs-dkms.git /opt/shiftfs-k5.4 \
     && git clone --branch k5.10 https://github.com/nestybox/shiftfs-dkms.git /opt/shiftfs-k5.10 \
     && git clone --branch k5.11 https://github.com/nestybox/shiftfs-dkms.git /opt/shiftfs-k5.11 \
-    && git clone --branch k5.13 https://github.com/nestybox/shiftfs-dkms.git /opt/shiftfs-k5.13
+    && git clone --branch k5.13 https://github.com/nestybox/shiftfs-dkms.git /opt/shiftfs-k5.13 \
+    && git clone --branch k5.16 https://github.com/nestybox/shiftfs-dkms.git /opt/shiftfs-k5.16 \
+    && git clone --branch k5.17 https://github.com/nestybox/shiftfs-dkms.git /opt/shiftfs-k5.17 \
+    && git clone --branch k5.18 https://github.com/nestybox/shiftfs-dkms.git /opt/shiftfs-k5.18
 
 #
 # Load Sysbox installation artifacts

--- a/k8s/Dockerfile.sysbox-ee
+++ b/k8s/Dockerfile.sysbox-ee
@@ -47,7 +47,10 @@ RUN wget https://github.com/kubernetes-sigs/cri-tools/releases/download/${CRICTL
 RUN git clone --branch k5.4 https://github.com/nestybox/shiftfs-dkms.git /opt/shiftfs-k5.4 \
     && git clone --branch k5.10 https://github.com/nestybox/shiftfs-dkms.git /opt/shiftfs-k5.10 \
     && git clone --branch k5.11 https://github.com/nestybox/shiftfs-dkms.git /opt/shiftfs-k5.11 \
-    && git clone --branch k5.13 https://github.com/nestybox/shiftfs-dkms.git /opt/shiftfs-k5.13
+    && git clone --branch k5.13 https://github.com/nestybox/shiftfs-dkms.git /opt/shiftfs-k5.13 \
+    && git clone --branch k5.16 https://github.com/nestybox/shiftfs-dkms.git /opt/shiftfs-k5.16 \
+    && git clone --branch k5.17 https://github.com/nestybox/shiftfs-dkms.git /opt/shiftfs-k5.17 \
+    && git clone --branch k5.18 https://github.com/nestybox/shiftfs-dkms.git /opt/shiftfs-k5.18
 
 #
 # Load Sysbox installation artifacts

--- a/k8s/scripts/sysbox-deploy-k8s.sh
+++ b/k8s/scripts/sysbox-deploy-k8s.sh
@@ -454,9 +454,18 @@ function install_sysbox_deps() {
 		elif semver_ge $kversion 5.11 && semver_lt $kversion 5.13; then
 			echo "Kernel version $kversion is >= 5.11 and < 5.13"
 			cp -r "/opt/shiftfs-k5.11" "$host_run/shiftfs-dkms"
-		else
-			echo "Kernel version $kversion is >= 5.13"
+		elif semver_ge $kversion 5.13 && semver_lt $kversion 5.15; then
+			echo "Kernel version $kversion is >= 5.13 and < 5.15"
 			cp -r "/opt/shiftfs-k5.13" "$host_run/shiftfs-dkms"
+		elif semver_ge $kversion 5.15 && semver_lt $kversion 5.17; then
+			echo "Kernel version $kversion is >= 5.15 and < 5.17"
+			cp -r "/opt/shiftfs-k5.16" "$host_run/shiftfs-dkms"
+		elif semver_ge $kversion 5.17 && semver_lt $kversion 5.18; then
+			echo "Kernel version $kversion is 5.17"
+			cp -r "/opt/shiftfs-k5.17" "$host_run/shiftfs-dkms"
+		else
+			echo "Kernel version $kversion is >= 5.18"
+			cp -r "/opt/shiftfs-k5.18" "$host_run/shiftfs-dkms"
 		fi
 	fi
 


### PR DESCRIPTION
Prior to this change, sysbox-deploy-k8s only supported shiftfs
on Linux kernels <= 5.13. With this change, support is extended
to kernels <= 5.18.

Signed-off-by: Cesar Talledo <cesar.talledo@docker.com>