### PR TITLE
Remove stale crio-bld containers after build.

### DIFF
--- a/k8s/Makefile
+++ b/k8s/Makefile
@@ -142,7 +142,7 @@ $(FLATCAR_DEV_ENVS):
 #
 
 build-crio: crio-build-container
-	docker run -v $(shell pwd)/bin:/mnt/results crio-bld
+	docker run --rm -v $(shell pwd)/bin:/mnt/results crio-bld
 
 
 crio-build-container:


### PR DESCRIPTION
Signed-off-by: Cesar Talledo <cesar.talledo@docker.com>