### PR TITLE
Use version patch field in image tagging.

### DIFF
--- a/deb/changelog_convert.sh
+++ b/deb/changelog_convert.sh
@@ -77,15 +77,15 @@ function print_tag_header() {
 
     if [[ "$SYSBOX_RELEASE" = "true" ]]; then
         if [[ $unreleased = true ]]; then
-            echo -e "sysbox-${EDITION} (${tag}-0.linux) UNRELEASED; urgency=medium\n"
+            echo -e "sysbox-${EDITION} (${tag}.linux) UNRELEASED; urgency=medium\n"
         else
-            echo -e "sysbox-${EDITION} (${tag}-0.linux) unstable; urgency=medium\n"
+            echo -e "sysbox-${EDITION} (${tag}.linux) unstable; urgency=medium\n"
         fi
     else
         if [[ $unreleased = true ]]; then
-            echo -e "sysbox-${EDITION} (${tag}-0.${BASE_DISTRO}-${BASE_DISTRO_RELEASE}) UNRELEASED; urgency=medium\n"
+            echo -e "sysbox-${EDITION} (${tag}.${BASE_DISTRO}-${BASE_DISTRO_RELEASE}) UNRELEASED; urgency=medium\n"
         else
-            echo -e "sysbox-${EDITION} (${tag}-0.${BASE_DISTRO}-${BASE_DISTRO_RELEASE}) unstable; urgency=medium\n"
+            echo -e "sysbox-${EDITION} (${tag}.${BASE_DISTRO}-${BASE_DISTRO_RELEASE}) unstable; urgency=medium\n"
         fi
     fi
 }


### PR DESCRIPTION
Prior to this commit, the sysbox package builder was ignoring the patch field (e.g., the last field in version "0.6.0-1") and instead using patch number "-0" always. With this commit the sysbox-pkgr will pick up the patch number from the VERSION or CHANGELOG files as appropriate.

Signed-off-by: Cesar Talledo <cesar.talledo@docker.com>