### PR TITLE
sysbox-deploy-k8s: remove support for k8s v1.22

### DIFF
--- a/k8s/scripts/sysbox-deploy-k8s.sh
+++ b/k8s/scripts/sysbox-deploy-k8s.sh
@@ -744,8 +744,7 @@ function is_supported_k8s_version() {
 
 	local ver=$k8s_version
 
-	if [[ "$ver" == "v1.22" ]] ||
-		[[ "$ver" == "v1.23" ]] ||
+	if [[ "$ver" == "v1.23" ]] ||
 		[[ "$ver" == "v1.24" ]] ||
 		[[ "$ver" == "v1.25" ]] ||
 		[[ "$ver" == "v1.26" ]]; then
@@ -754,7 +753,8 @@ function is_supported_k8s_version() {
 
 	if [[ "$ver" == "v1.19" ]] ||
 		[[ "$ver" == "v1.20" ]] ||
-		[[ "$ver" == "v1.21" ]]; then
+		[[ "$ver" == "v1.21" ]] ||
+		[[ "$ver" == "v1.22" ]]; then
 		echo "Unsupported kubernetes version: $ver (EOL release)."
 	fi
 


### PR DESCRIPTION
K8s v1.22 is EOL'd on 10/28/22. Remove support for it in sysbox-deploy-k8s.