### PR TITLE
Add detection for RKE2 controller service in daemonset installer

### DIFF
--- a/k8s/scripts/kubelet-unconfig-helper.sh
+++ b/k8s/scripts/kubelet-unconfig-helper.sh
@@ -316,14 +316,20 @@ function kubelet_rke_deployment() {
 # service
 ###############################################################################
 
+function get_rke2_service_name() {
+	# figure out which rke2 service is running
+	# one of these must be active because of the check in kubelet_rke2_deployment
+	systemctl list-units --type service --state active --quiet --plain 'rke2-*' | cut -d ' ' -f1
+}
+
 function start_rke2() {
-	echo "Starting RKE2 agent ..."
-	systemctl start rke2-agent
+	echo "Starting RKE2 service $1 ..."
+	systemctl start $1
 }
 
 function stop_rke2() {
-	echo "Stopping RKE2 agent ..."
-	systemctl stop rke2-agent
+	echo "Stopping RKE2 service $1 ..."
+	systemctl stop $1
 }
 
 function revert_kubelet_config_rke2() {
@@ -357,16 +363,18 @@ function do_unconfig_kubelet_rke2() {
 		return
 	fi
 
-	stop_rke2
+	local rke2_service_name=$(get_rke2_service_name) # rke2-agent or rke2-server
+	stop_rke2 "$rke2_service_name"
 	clean_runtime_state
 	revert_kubelet_config_rke2
-	start_rke2
+	start_rke2 "$rke2_service_name"
 }
 
 function kubelet_rke2_deployment() {
 
-	# Worker nodes in RKE2 setups rely on rke2-agent's systemd service.
-	if systemctl is-active --quiet rke2-agent; then
+	# Worker nodes in RKE2 setups rely on rke2-agent's systemd service,
+	# or rke2-server for single-node clusters (there is only the controller node)
+	if systemctl is-active --quiet rke2-agent rke2-server; then
 		return
 	fi
 


### PR DESCRIPTION
Previously, only `rke2-agent.service` was used for detecting RKE2-based clusters, but in a single node cluster there is only the controller node with `rke2-server.service` running instead.

This adds support for checking for `rke2-server.service` and handles stopping/starting whichever service is running on the node.

Fixes https://github.com/nestybox/sysbox/issues/692.
