### PR TITLE
Disable sysbox inner image preloading for K8s deployments.

### DIFF
--- a/k8s/systemd/sysbox-mgr.service
+++ b/k8s/systemd/sysbox-mgr.service
@@ -5,7 +5,7 @@ PartOf=sysbox.service
 [Service]
 Type=simple
 Type=notify
-ExecStart=/usr/bin/sysbox-mgr
+ExecStart=/usr/bin/sysbox-mgr --disable-inner-image-preload
 TimeoutStartSec=45
 TimeoutStopSec=90
 StartLimitInterval=0


### PR DESCRIPTION
The feature is only useful when using "docker build" or "docker commit" to create container images that come preloaded with inner container images. By disabling it in K8s, sysbox pod stopping will become faster (and can be significantly faster if the pod had a docker engine inside that pulled lots of inner container images.