### PR TITLE
Initial attempt at GKE detection in sysbox-deploy-k8s script

### DIFF
--- a/k8s/scripts/sysbox-deploy-k8s.sh
+++ b/k8s/scripts/sysbox-deploy-k8s.sh
@@ -950,6 +950,8 @@ function do_distro_adjustments() {
 
 # determines if running on a GKE cluster by checking metadata endpoint
 function check_gke() {
+	# GKE nodes will respond with an HTTP 200 for this URL and Metadata-Flavor header.
+	# Other clouds, URLs, etc. will throw a 404 error. If curl cannot connect the code will be 000.
 	is_cluster=$(curl -s -o /dev/null \
 	 		-w "%{http_code}" \
 	   		--connect-timeout 1 \

--- a/k8s/scripts/sysbox-deploy-k8s.sh
+++ b/k8s/scripts/sysbox-deploy-k8s.sh
@@ -948,17 +948,21 @@ function do_distro_adjustments() {
 	sed -i '/^kernel.unprivileged_userns_clone/ s/^#*/# /' ${sysbox_artifacts}/systemd/99-sysbox-sysctl.conf
 }
 
-# determines if running on a GKE cluster
+# determines if running on a GKE cluster by checking metadata endpoint
 function check_gke() {
-	cluster_name=$(curl --connect-timeout 1 -s -H "Metadata-Flavor: Google" 169.254.169.254/computeMetadata/v1/instance/attributes/cluster-name || false)
-	if [[ -z $cluster_name ]]; then
+	is_cluster=$(curl -s -o /dev/null \
+	 		-w "%{http_code}" \
+	   		--connect-timeout 1 \
+	     		-H "Metadata-Flavor: Google" \
+	       		169.254.169.254/computeMetadata/v1/instance/attributes/cluster-name)
+	if [ $is_cluster -ne 200 ]; then
 		false
 		return
 	fi
 	true
 }
 
-# fixes issue with network bridge on GKE not working
+# fixes issue with crio network bridge on GKE not working
 # also adds correct path to k8s binaries on GKE nodes in /home/kubernetes/bin
 function config_crio_for_gke() {
 	rm ${host_etc}/cni/net.d/100-crio-bridge.conf

--- a/k8s/scripts/sysbox-deploy-k8s.sh
+++ b/k8s/scripts/sysbox-deploy-k8s.sh
@@ -948,6 +948,24 @@ function do_distro_adjustments() {
 	sed -i '/^kernel.unprivileged_userns_clone/ s/^#*/# /' ${sysbox_artifacts}/systemd/99-sysbox-sysctl.conf
 }
 
+# determines if running on a GKE cluster
+function check_gke() {
+	cluster_name=$(curl --connect-timeout 1 -s -H "Metadata-Flavor: Google" 169.254.169.254/computeMetadata/v1/instance/attributes/cluster-name || false)
+	if [[ -z $cluster_name ]]; then
+		false
+		return
+	fi
+	true
+}
+
+# fixes issue with network bridge on GKE not working
+# also adds correct path to k8s binaries on GKE nodes in /home/kubernetes/bin
+function config_crio_for_gke() {
+	rm ${host_etc}/cni/net.d/100-crio-bridge.conf
+	dasel put string -f ${host_crio_conf_file} -p toml -m 'crio.network.plugin_dirs.[]' "/opt/cni/bin/"
+	dasel put string -f ${host_crio_conf_file} -p toml -m 'crio.network.plugin_dirs.[]' "/home/kubernetes/bin"
+}
+
 #
 # Main Function
 #
@@ -1022,6 +1040,11 @@ function main() {
 			deploy_crio_installer_service
 			remove_crio_installer_service
 			config_crio
+			# check if running on GKE, and if so, patch crio config
+			if check_gke; then
+				echo "Configuring CRI-O for GKE"
+				config_crio_for_gke
+			fi
 			crio_restart_pending=true
 			echo "yes" >${host_var_lib_sysbox_deploy_k8s}/crio_installed
 		fi


### PR DESCRIPTION
Here's an initial attempt at resolving https://github.com/nestybox/sysbox/issues/680.

The idea is the `sysbox-deploy-k8s.sh` script checks if the link local Google metadata endpoint is available at 169.254.169.254 and then to see if the host node is part of a GKE cluster.

If so, then the script removes the conflicting bridge configuration, and sets the correct paths in the crio.network toml config.

Could definitely use some proper testing from someone who knows their way around the install process!