### PR TITLE
Fix sysbox install compatibility with GKE

### DIFF
--- a/k8s/scripts/sysbox-deploy-k8s.sh
+++ b/k8s/scripts/sysbox-deploy-k8s.sh
@@ -611,6 +611,12 @@ function config_crio_for_sysbox() {
 	if host_flatcar_distro; then
 		sed -i 's@/usr/bin/sysbox-runc@/opt/bin/sysbox-runc@' ${host_crio_conf_file}
 	fi
+
+	# In GKE configure existing plugins 
+	if is_host_gke; then
+		dasel put string -f ${host_crio_conf_file} -p toml -m 'crio.network.plugin_dirs.[]' "/opt/cni/bin/"
+		dasel put string -f ${host_crio_conf_file} -p toml -m 'crio.network.plugin_dirs.[]' "/home/kubernetes/bin"
+	fi
 }
 
 function unconfig_crio_for_sysbox() {
@@ -691,6 +697,10 @@ function host_flatcar_distro() {
 
 function get_host_kernel() {
 	uname -r
+}
+
+function is_host_gke() {
+	curl -Ls -o /dev/null "http://metadata.google.internal/computeMetadata/v1/instance/image" -H "Metadata-Flavor: Google" && true || false
 }
 
 function is_supported_distro() {


### PR DESCRIPTION
Fixes https://github.com/nestybox/sysbox/issues/680

Thanks @jamonation for finding the manual fix at https://github.com/nestybox/sysbox/issues/680#issuecomment-1528597856, so this should implement those changes for GKE users. Although, it seems fine to leave the loopback CNI at  `/etc/cni/net.d/200-loopback.conf`

I used the following steps to build the container on this branch locally, pushed to a local mirror, and deployed to GKE (running GKE 1.24.14-gke.1400 - Ubuntu with containerd node pool) resolving our issue:
- `make sysbox-ce-repo`
- `make sources/sysbox`
- `cd k8s/ && make sysbox-deploy-k8s-image`

I have not tested on any other platforms or versions.

Happy to take suggestions and re-test if needed.