### PR TITLE
Allow installing K8S daemonset on Debian hosts

### DIFF
--- a/k8s/scripts/sysbox-deploy-k8s.sh
+++ b/k8s/scripts/sysbox-deploy-k8s.sh
@@ -261,7 +261,8 @@ function get_artifacts_dir() {
 	if [[ "$distro" == "ubuntu-22.04" ]] ||
 		[[ "$distro" == "ubuntu-21.10" ]] ||
 		[[ "$distro" == "ubuntu-20.04" ]] ||
-		[[ "$distro" == "ubuntu-18.04" ]]; then
+		[[ "$distro" == "ubuntu-18.04" ]] ||
+		[[ "$distro" =~ "debian" ]]; then
 		artifacts_dir="${sysbox_artifacts}/bin/generic"
 	elif [[ "$distro" =~ "flatcar" ]]; then
 		local release=$(echo $distro | cut -d"-" -f2)

--- a/k8s/scripts/sysbox-deploy-k8s.sh
+++ b/k8s/scripts/sysbox-deploy-k8s.sh
@@ -507,22 +507,22 @@ function get_subid_limits() {
 	fi
 
 	set +e
-	res=$(grep "^SUB_UID_MIN" $subid_def_file >/dev/null 2>&1)
+	res=$(grep "^SUB_UID_MIN" $subid_def_file 2>/dev/null)
 	if [ $? -eq 0 ]; then
 		subuid_min=$(echo $res | cut -d " " -f2)
 	fi
 
-	res=$(grep "^SUB_UID_MAX" $subid_def_file >/dev/null 2>&1)
+	res=$(grep "^SUB_UID_MAX" $subid_def_file 2>/dev/null)
 	if [ $? -eq 0 ]; then
 		subuid_max=$(echo $res | cut -d " " -f2)
 	fi
 
-	res=$(grep "^SUB_GID_MIN" $subid_def_file >/dev/null 2>&1)
+	res=$(grep "^SUB_GID_MIN" $subid_def_file 2>/dev/null)
 	if [ $? -eq 0 ]; then
 		subgid_min=$(echo $res | cut -d " " -f2)
 	fi
 
-	res=$(grep "^SUB_GID_MAX" $subid_def_file >/dev/null 2>&1)
+	res=$(grep "^SUB_GID_MAX" $subid_def_file 2>/dev/null)
 	if [ $? -eq 0 ]; then
 		subgid_max=$(echo $res | cut -d " " -f2)
 	fi


### PR DESCRIPTION
Debian has been half-marked as a supported host in `is_supported_distro` since 698afc4, but support was not fully plumbed. This PR adds proper support for Debian in the other distro check for copying artifacts.

Coupled with #115, this allows Sysbox to be installed on DigitalOcean's managed Kubernetes, which use Debian 12 nodes on kernel 6.1.

---

This also includes a fix for reading the subid defaults from `/etc/login.defs`, where the grep output was always discarded, causing the userns mapping range to start at 0, which in turn caused fun errors such as:

> ```
> error in container spec: invalid user/group ID config: detected user-ns uid mapping to host ID 0 
>   ({0 0 65536}); this breaks container isolation
> ```

This mapping error seems to have only affected systems where `/etc/sub*id`  are created fresh (e.g. DO's nodes), and not if there were preexisting entries for other users where finding a valid hole to fit new mappings re-set the bad start value.
