### PR TITLE
Skip installing shiftfs module in K8S daemonset when kernel is >= 5.19

### DIFF
--- a/k8s/Dockerfile.sysbox-ce
+++ b/k8s/Dockerfile.sysbox-ce
@@ -47,7 +47,8 @@ RUN git clone --branch k5.4 https://github.com/nestybox/shiftfs-dkms.git /opt/sh
     && git clone --branch k5.13 https://github.com/nestybox/shiftfs-dkms.git /opt/shiftfs-k5.13 \
     && git clone --branch k5.16 https://github.com/nestybox/shiftfs-dkms.git /opt/shiftfs-k5.16 \
     && git clone --branch k5.17 https://github.com/nestybox/shiftfs-dkms.git /opt/shiftfs-k5.17 \
-    && git clone --branch k5.18 https://github.com/nestybox/shiftfs-dkms.git /opt/shiftfs-k5.18
+    && git clone --branch k5.18 https://github.com/nestybox/shiftfs-dkms.git /opt/shiftfs-k5.18 \
+    && git clone --branch k6.1 https://github.com/toby63/shiftfs-dkms.git /opt/shiftfs-k6.1
 
 #
 # Load Sysbox installation artifacts

--- a/k8s/Dockerfile.sysbox-ce
+++ b/k8s/Dockerfile.sysbox-ce
@@ -48,7 +48,7 @@ RUN git clone --branch k5.4 https://github.com/nestybox/shiftfs-dkms.git /opt/sh
     && git clone --branch k5.16 https://github.com/nestybox/shiftfs-dkms.git /opt/shiftfs-k5.16 \
     && git clone --branch k5.17 https://github.com/nestybox/shiftfs-dkms.git /opt/shiftfs-k5.17 \
     && git clone --branch k5.18 https://github.com/nestybox/shiftfs-dkms.git /opt/shiftfs-k5.18 \
-    && git clone --branch k6.1 https://github.com/toby63/shiftfs-dkms.git /opt/shiftfs-k6.1
+    && git clone --branch k6.1 https://github.com/nestybox/shiftfs-dkms.git /opt/shiftfs-k6.1
 
 #
 # Load Sysbox installation artifacts

--- a/k8s/scripts/sysbox-deploy-k8s.sh
+++ b/k8s/scripts/sysbox-deploy-k8s.sh
@@ -76,6 +76,7 @@ subgid_file="${host_etc}/subgid"
 
 # Shiftfs
 shiftfs_min_kernel_ver=5.4
+shiftfs_max_kernel_ver=5.18
 
 # Current OS distro and kernel release
 os_distro_release=""
@@ -474,9 +475,12 @@ function install_sysbox_deps() {
 		elif semver_ge $kversion 5.17 && semver_lt $kversion 5.18; then
 			echo "Kernel version $kversion is 5.17"
 			cp -r "/opt/shiftfs-k5.17" "$host_run/shiftfs-dkms"
-		else
-			echo "Kernel version $kversion is >= 5.18"
+		elif semver_ge $kversion 5.18 && semver_lt $kversion 5.19; then
+			echo "Kernel version $kversion is 5.18"
 			cp -r "/opt/shiftfs-k5.18" "$host_run/shiftfs-dkms"
+		else
+			echo "Kernel version $kversion is >= 5.19"
+			# dont copy shiftfs, but still proceed to install other deps
 		fi
 	fi
 

--- a/k8s/scripts/sysbox-deploy-k8s.sh
+++ b/k8s/scripts/sysbox-deploy-k8s.sh
@@ -76,7 +76,7 @@ subgid_file="${host_etc}/subgid"
 
 # Shiftfs
 shiftfs_min_kernel_ver=5.4
-shiftfs_max_kernel_ver=5.18
+shiftfs_max_kernel_ver=6.2
 
 # Current OS distro and kernel release
 os_distro_release=""
@@ -475,11 +475,14 @@ function install_sysbox_deps() {
 		elif semver_ge $kversion 5.17 && semver_lt $kversion 5.18; then
 			echo "Kernel version $kversion is 5.17"
 			cp -r "/opt/shiftfs-k5.17" "$host_run/shiftfs-dkms"
-		elif semver_ge $kversion 5.18 && semver_lt $kversion 5.19; then
-			echo "Kernel version $kversion is 5.18"
+		elif semver_ge $kversion 5.18 && semver_lt $kversion 6.1; then
+			echo "Kernel version $kversion is >= 5.18 and < 6.1"
 			cp -r "/opt/shiftfs-k5.18" "$host_run/shiftfs-dkms"
+		elif semver_ge $kversion 6.1 && semver_lt $kversion 6.3; then
+			echo "Kernel version $kversion is >= 6.1 and < 6.3"
+			cp -r "/opt/shiftfs-k6.1" "$host_run/shiftfs-dkms"
 		else
-			echo "Kernel version $kversion is >= 5.19"
+			echo "Kernel version $kversion, which is above the max required for shiftfs ($shiftfs_max_kernel_ver); skipping shiftfs installation."
 			# dont copy shiftfs, but still proceed to install other deps
 		fi
 	fi

--- a/k8s/scripts/sysbox-installer-helper.sh
+++ b/k8s/scripts/sysbox-installer-helper.sh
@@ -76,13 +76,14 @@ function compare_ge() {
 }
 
 function shiftfs_needed() {
-	# shiftfs is not needed or recommended on kernels >= 5.19
-	# where idmapped mounts are present and stable
+	# shiftfs is not needed for kernels >= 5.19 where idmapped mounts are present
+	# and stable, but is still recommended if it is available. the max supported
+	# version for shiftfs is 6.2, so check against that here
 	local kversion=$(uname -r | cut -d "." -f1-2)
 
 	# do not need full semver comparison since kversion will be X.Y thanks to cut
-	if compare_ge $kversion 5.19; then
-		# kernel is >= 5.19, not needed
+	if compare_ge $kversion 6.2; then
+		# not needed
 		return 1
 	else
 		return 0


### PR DESCRIPTION
This PR tweaks the daemonset deploy and installer helper scripts to skip copying and building shiftfs if the host kernel is 5.19+. As [Shiftfs is not required by Sysbox](https://github.com/nestybox/sysbox/blob/v0.6.2/docs/user-guide/design.md#shiftfs-module) on these versions, deploying and installing shiftfs here will block installations on hosts using a newer kernel than what the bundled module supports. 

Coupled with #114, this allows Sysbox to be installed on DigitalOcean's managed Kubernetes, which use Debian 12 nodes on kernel 6.1.