### PR TITLE
Fix missing required variable

### DIFF
--- a/deb/sysbox-ce/sysbox-ce.config
+++ b/deb/sysbox-ce/sysbox-ce.config
@@ -8,6 +8,10 @@ set -e
 # Source debconf library.
 . /usr/share/debconf/confmodule
 
+# Dockerd default configuration dir/file.
+dockerCfgDir="/etc/docker"
+dockerCfgFile="${dockerCfgDir}/daemon.json"
+
 # UID-shifting module
 shiftfs_module="shiftfs"
 

--- a/deb/sysbox-ee/sysbox-ee.config
+++ b/deb/sysbox-ee/sysbox-ee.config
@@ -8,6 +8,10 @@ set -e
 # Source debconf library.
 . /usr/share/debconf/confmodule
 
+# Dockerd default configuration dir/file.
+dockerCfgDir="/etc/docker"
+dockerCfgFile="${dockerCfgDir}/daemon.json"
+
 # UID-shifting module
 shiftfs_module="shiftfs"
 


### PR DESCRIPTION
The dockerCfgFile is used in docker_network_valid_config function, but is not defined. Fix this by re-adding it.

Fixes: #110