### PR TITLE
Add WSL2 detector

### DIFF
--- a/deb/sysbox-ce/sysbox-ce.postinst
+++ b/deb/sysbox-ce/sysbox-ce.postinst
@@ -72,6 +72,15 @@ function create_sysboxfs_mountpoint() {
     fi
 }
 
+# Ensure WSL2 kernel detected.
+function is_wsl() {
+    case "$(uname -r)" in
+    *microsoft* ) true ;; # WSL 2
+    *Microsoft* ) true ;; # WSL 1
+    * ) false;;
+    esac
+}
+
 # Enables the utilization of unprivileged user-namespaces.
 function enable_unprivileged_userns() {
 
@@ -315,7 +324,11 @@ function config_sysbox() {
     # Allows user-namespaces creation for unprivileged users. This change will
     # persist through system reboots by relying on a sysctl.d config-file to be
     # generated as part of this package's installation process.
-    enable_unprivileged_userns
+    if is_wsl; then
+        echo "WSL2 detected, enable_unprivileged_userns skipped."
+    else
+        enable_unprivileged_userns
+    fi
 
     # Ensure kernel's inotify resources can meet Sysbox's scaling requirements.
     define_inotify_resources
@@ -338,7 +351,11 @@ function config_sysbox() {
     fi
 
     # Check for kernel-headers.
-    check_kernel_headers
+    if is_wsl; then
+        echo "WSL2 detected, check_kernel_headers skipped."
+    else
+        check_kernel_headers
+    fi
 }
 
 case "$1" in


### PR DESCRIPTION
- Fixes nestybox/sysbox#32

### summary

- To install sysbox  on wsl2
  - skip `unprivileged_userns_clone`
  - skip kernel header install

### install

```powershell
wsl --install --no-distribution
wsl --install --distribution Ubuntu-22.04
```

```bash
sudo apt-get update
sudo apt-get upgrade -y
sudo apt-get install -y ca-certificates curl gnupg jq

# install docker
sudo curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc
echo 'deb [arch=amd64 signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu jammy stable' | sudo tee /etc/apt/sources.list.d/docker.list
sudo apt-get update
sudo apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin

# install sysbox
sudo dpkg -i /app/sysbox-ce_0.6.3.linux_amd64.deb
```

### install-logs

```
$ sudo dpkg -i /app/sysbox-ce_0.6.3.linux_amd64.deb
[sudo] password for sysbox:
(Reading database ... 24514 files and directories currently installed.)
Preparing to unpack .../sysbox-ce_0.6.3.linux_amd64.deb ...
Unpacking sysbox-ce (0.6.3.linux) over (0.6.3.linux) ...
Setting up sysbox-ce (0.6.3.linux) ...
WSL2 detected, enable_unprivileged_userns skipped.
WSL2 detected, check_kernel_headers skipped.
```

### Tests

```yaml
# ✅OK
services:
  dind-sysbox:
    image: docker.io/library/docker:24.0.7-alpine3.19
    container_name: dind
    runtime: sysbox-runc
    privileged: false
    tty: true
```
```
$ sudo docker compose up -d
[+] Running 1/1
 ✔ Container dind  Started                                                                                                                                   1.4s
$ sudo docker container ls -a
CONTAINER ID   IMAGE                      COMMAND                  CREATED         STATUS         PORTS           NAMES
0f70116fe635   docker:24.0.7-alpine3.19   "dockerd-entrypoint.…"   6 seconds ago   Up 3 seconds   2375-2376/tcp   dind
$ sudo docker container logs dind
Certificate request self-signature ok
subject=CN = docker:dind server
/certs/server/cert.pem: OK
Certificate request self-signature ok
subject=CN = docker:dind client
/certs/client/cert.pem: OK
iptables v1.8.10 (nf_tables)
mount: mounting none on /sys/kernel/security failed: No such device
Could not mount /sys/kernel/security.
AppArmor detection and --privileged mode might break.
INFO[2024-01-12T12:58:17.428526877Z] Starting up
INFO[2024-01-12T12:58:17.450378076Z] containerd not running, starting managed containerd
INFO[2024-01-12T12:58:17.451148976Z] started new containerd process                address=/var/run/docker/containerd/containerd.sock module=libcontainerd pid=175
INFO[2024-01-12T12:58:17.465263075Z] starting containerd                           revision=091922f03c2762540fd057fba91260237ff86acb version=v1.7.6
```
