### PR TITLE
Enable clone without sshkeys.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,7 +79,7 @@ sysbox-ce-repo:
 
 sources/sysbox:
 	@printf "\n*** Cloning sysbox-ce superproject repository to $(CE_SOURCES) ***\n\n"
-	@git clone --recursive git@github.com:nestybox/sysbox.git sources/sysbox
+	@git clone --recursive https://github.com/nestybox/sysbox.git sources/sysbox
 
 ##@ Testing targets
 


### PR DESCRIPTION
- Enable clone without sshkeys.
  - If you just want to build sysbox-pkgr, ssh-keys is not required.