### PR TITLE
Support custom taint

### DIFF
--- a/k8s/scripts/sysbox-deploy-k8s.sh
+++ b/k8s/scripts/sysbox-deploy-k8s.sh
@@ -1103,7 +1103,7 @@ function main() {
 
 		add_label_to_node "crio-runtime=running"
 		add_label_to_node "sysbox-runtime=running"
-		rm_taint_from_node "sysbox-runtime=not-running:NoSchedule"
+		rm_taint_from_node "${k8s_tains}"
 
 		echo "The k8s runtime on this node is now CRI-O."
 		echo "$sysbox_edition installation completed."
@@ -1159,7 +1159,7 @@ function main() {
 			restart_crio
 		fi
 
-		rm_taint_from_node "sysbox-runtime=not-running:NoSchedule"
+		rm_taint_from_node "${k8s_tains}"
 
 		echo "The k8s runtime on this node is now $k8s_runtime."
 		;;

--- a/k8s/scripts/sysbox-deploy-k8s.sh
+++ b/k8s/scripts/sysbox-deploy-k8s.sh
@@ -1020,6 +1020,8 @@ function main() {
 		k8s_runtime="crio"
 	fi
 
+	k8s_tains=${SYSBOX_TAINT:-"sysbox-runtime=not-running:NoSchedule"}
+
 	echo "Detected Kubernetes version $k8s_version"
 
 	local edition_tag=${1:-}
@@ -1048,7 +1050,7 @@ function main() {
 		install_precheck
 
 		# Prevent new pods being scheduled till sysbox installation is completed.
-		add_taint_to_node "sysbox-runtime=not-running:NoSchedule"
+		add_taint_to_node "${k8s_tains}"
 
 		# Install CRI-O
 		if [[ "$do_crio_install" == "true" ]]; then
@@ -1111,7 +1113,7 @@ function main() {
 		mkdir -p ${host_var_lib_sysbox_deploy_k8s}
 
 		# Prevent new pods being scheduled during sysbox cleanup phase.
-		add_taint_to_node "sysbox-runtime=not-running:NoSchedule"
+		add_taint_to_node "${k8s_tains}"
 
 		# Switch the K8s runtime away from CRI-O (but only if this daemonset installed CRI-O previously)
 		if [ -f ${host_var_lib_sysbox_deploy_k8s}/crio_installed ] && [[ "$k8s_runtime" == "crio" ]]; then


### PR DESCRIPTION
Closes #117

This would allow one to set `SYSBOX_TAINT=startup-taint.cluster-autoscaler.kubernetes.io/sysbox-runtime=not-running:NoSchedule`
Which would let GKE know whats going on