### PR TITLE
Add support for k8s v1.30 and deprecate v1.26

### DIFF
--- a/k8s/Dockerfile.sysbox-ce
+++ b/k8s/Dockerfile.sysbox-ce
@@ -21,6 +21,7 @@ ARG sys_arch
 ENV SYS_ARCH=${sys_arch}
 ARG DEST=/opt/sysbox
 ARG CRICTL_VERSION="v1.28.0"
+ARG CRIO_V1_27_TAR="cri-o.${SYS_ARCH}.v1.27.0.tar.gz"
 ARG CRIO_V1_28_TAR="cri-o.${SYS_ARCH}.v1.28.0.tar.gz"
 ARG CRIO_V1_29_TAR="cri-o.${SYS_ARCH}.v1.29.0.tar.gz"
 ARG CRIO_V1_30_TAR="cri-o.${SYS_ARCH}.v1.30.0.tar.gz"
@@ -71,6 +72,10 @@ COPY scripts/sysbox-removal-helper.sh /opt/sysbox/scripts/sysbox-removal-helper.
 # Load CRI-O installation artifacts
 #
 
+RUN wget https://storage.googleapis.com/cri-o/artifacts/${CRIO_V1_27_TAR} -O cri-o.${SYS_ARCH}.tar.gz \
+    && mkdir -p /opt/crio-deploy/bin/v1.27 \
+    && mv cri-o.${SYS_ARCH}.tar.gz /opt/crio-deploy/bin/v1.27/.
+
 RUN wget https://storage.googleapis.com/cri-o/artifacts/${CRIO_V1_28_TAR} -O cri-o.${SYS_ARCH}.tar.gz \
     && mkdir -p /opt/crio-deploy/bin/v1.28 \
     && mv cri-o.${SYS_ARCH}.tar.gz /opt/crio-deploy/bin/v1.28/.
@@ -108,6 +113,7 @@ COPY config/etc_containers_registries.d_default.yaml /opt/crio-deploy/config/etc
 # Load CRI-O patched binaries (to generate correct user-ns mappings)
 #
 
+COPY bin/crio/v1.27/crio /opt/crio-deploy/bin/v1.27/crio-patched
 COPY bin/crio/v1.28/crio /opt/crio-deploy/bin/v1.28/crio-patched
 COPY bin/crio/v1.29/crio /opt/crio-deploy/bin/v1.29/crio-patched
 COPY bin/crio/v1.30/crio /opt/crio-deploy/bin/v1.30/crio-patched

--- a/k8s/Dockerfile.sysbox-ce
+++ b/k8s/Dockerfile.sysbox-ce
@@ -21,7 +21,6 @@ ARG sys_arch
 ENV SYS_ARCH=${sys_arch}
 ARG DEST=/opt/sysbox
 ARG CRICTL_VERSION="v1.28.0"
-ARG CRIO_V1_26_TAR="cri-o.${SYS_ARCH}.v1.26.0.tar.gz"
 ARG CRIO_V1_27_TAR="cri-o.${SYS_ARCH}.v1.27.0.tar.gz"
 ARG CRIO_V1_28_TAR="cri-o.${SYS_ARCH}.v1.28.0.tar.gz"
 ARG CRIO_V1_29_TAR="cri-o.${SYS_ARCH}.v1.29.0.tar.gz"
@@ -73,10 +72,6 @@ COPY scripts/sysbox-removal-helper.sh /opt/sysbox/scripts/sysbox-removal-helper.
 # Load CRI-O installation artifacts
 #
 
-RUN wget https://storage.googleapis.com/cri-o/artifacts/${CRIO_V1_26_TAR} -O cri-o.${SYS_ARCH}.tar.gz \
-    && mkdir -p /opt/crio-deploy/bin/v1.26 \
-    && mv cri-o.${SYS_ARCH}.tar.gz /opt/crio-deploy/bin/v1.26/.
-
 RUN wget https://storage.googleapis.com/cri-o/artifacts/${CRIO_V1_27_TAR} -O cri-o.${SYS_ARCH}.tar.gz \
     && mkdir -p /opt/crio-deploy/bin/v1.27 \
     && mv cri-o.${SYS_ARCH}.tar.gz /opt/crio-deploy/bin/v1.27/.
@@ -118,7 +113,6 @@ COPY config/etc_containers_registries.d_default.yaml /opt/crio-deploy/config/etc
 # Load CRI-O patched binaries (to generate correct user-ns mappings)
 #
 
-COPY bin/crio/v1.26/crio /opt/crio-deploy/bin/v1.26/crio-patched
 COPY bin/crio/v1.27/crio /opt/crio-deploy/bin/v1.27/crio-patched
 COPY bin/crio/v1.28/crio /opt/crio-deploy/bin/v1.28/crio-patched
 COPY bin/crio/v1.29/crio /opt/crio-deploy/bin/v1.29/crio-patched

--- a/k8s/Dockerfile.sysbox-ce
+++ b/k8s/Dockerfile.sysbox-ce
@@ -21,7 +21,6 @@ ARG sys_arch
 ENV SYS_ARCH=${sys_arch}
 ARG DEST=/opt/sysbox
 ARG CRICTL_VERSION="v1.28.0"
-ARG CRIO_V1_27_TAR="cri-o.${SYS_ARCH}.v1.27.0.tar.gz"
 ARG CRIO_V1_28_TAR="cri-o.${SYS_ARCH}.v1.28.0.tar.gz"
 ARG CRIO_V1_29_TAR="cri-o.${SYS_ARCH}.v1.29.0.tar.gz"
 ARG CRIO_V1_30_TAR="cri-o.${SYS_ARCH}.v1.30.0.tar.gz"
@@ -72,10 +71,6 @@ COPY scripts/sysbox-removal-helper.sh /opt/sysbox/scripts/sysbox-removal-helper.
 # Load CRI-O installation artifacts
 #
 
-RUN wget https://storage.googleapis.com/cri-o/artifacts/${CRIO_V1_27_TAR} -O cri-o.${SYS_ARCH}.tar.gz \
-    && mkdir -p /opt/crio-deploy/bin/v1.27 \
-    && mv cri-o.${SYS_ARCH}.tar.gz /opt/crio-deploy/bin/v1.27/.
-
 RUN wget https://storage.googleapis.com/cri-o/artifacts/${CRIO_V1_28_TAR} -O cri-o.${SYS_ARCH}.tar.gz \
     && mkdir -p /opt/crio-deploy/bin/v1.28 \
     && mv cri-o.${SYS_ARCH}.tar.gz /opt/crio-deploy/bin/v1.28/.
@@ -113,7 +108,6 @@ COPY config/etc_containers_registries.d_default.yaml /opt/crio-deploy/config/etc
 # Load CRI-O patched binaries (to generate correct user-ns mappings)
 #
 
-COPY bin/crio/v1.27/crio /opt/crio-deploy/bin/v1.27/crio-patched
 COPY bin/crio/v1.28/crio /opt/crio-deploy/bin/v1.28/crio-patched
 COPY bin/crio/v1.29/crio /opt/crio-deploy/bin/v1.29/crio-patched
 COPY bin/crio/v1.30/crio /opt/crio-deploy/bin/v1.30/crio-patched

--- a/k8s/Dockerfile.sysbox-ce
+++ b/k8s/Dockerfile.sysbox-ce
@@ -25,6 +25,7 @@ ARG CRIO_V1_26_TAR="cri-o.${SYS_ARCH}.v1.26.0.tar.gz"
 ARG CRIO_V1_27_TAR="cri-o.${SYS_ARCH}.v1.27.0.tar.gz"
 ARG CRIO_V1_28_TAR="cri-o.${SYS_ARCH}.v1.28.0.tar.gz"
 ARG CRIO_V1_29_TAR="cri-o.${SYS_ARCH}.v1.29.0.tar.gz"
+ARG CRIO_V1_30_TAR="cri-o.${SYS_ARCH}.v1.30.0.tar.gz"
 
 RUN yum install -y curl wget git bc which
 
@@ -88,6 +89,10 @@ RUN wget https://storage.googleapis.com/cri-o/artifacts/${CRIO_V1_29_TAR} -O cri
     && mkdir -p /opt/crio-deploy/bin/v1.29 \
     && mv cri-o.${SYS_ARCH}.tar.gz /opt/crio-deploy/bin/v1.29/.
 
+RUN wget https://storage.googleapis.com/cri-o/artifacts/${CRIO_V1_30_TAR} -O cri-o.${SYS_ARCH}.tar.gz \
+    && mkdir -p /opt/crio-deploy/bin/v1.30 \
+    && mv cri-o.${SYS_ARCH}.tar.gz /opt/crio-deploy/bin/v1.30/.
+
 COPY systemd/crio-installer.service /opt/crio-deploy/systemd/crio-installer.service
 COPY systemd/crio-removal.service /opt/crio-deploy/systemd/crio-removal.service
 COPY scripts/crio-extractor.sh /opt/crio-deploy/scripts/crio-extractor.sh
@@ -117,3 +122,4 @@ COPY bin/crio/v1.26/crio /opt/crio-deploy/bin/v1.26/crio-patched
 COPY bin/crio/v1.27/crio /opt/crio-deploy/bin/v1.27/crio-patched
 COPY bin/crio/v1.28/crio /opt/crio-deploy/bin/v1.28/crio-patched
 COPY bin/crio/v1.29/crio /opt/crio-deploy/bin/v1.29/crio-patched
+COPY bin/crio/v1.30/crio /opt/crio-deploy/bin/v1.30/crio-patched

--- a/k8s/Makefile
+++ b/k8s/Makefile
@@ -33,7 +33,7 @@ SYSBOX_CE_VER_SEMVER = $(shell echo $(SYSBOX_CE_VER) | cut -d"-" -f1)
 SYSBOX_CE_VER_FULL = $(shell echo $(SYSBOX_CE_VER) | sed '/-[0-9]/!s/.*/&-0/')
 
 # CRIO versions to build.
-CRIO_VERSIONS = v1.27 v1.28 v1.29 v1.30
+CRIO_VERSIONS = v1.28 v1.29 v1.30
 
 # Patch version is used to track changes to the sysbox-deploy-k8s image not related to
 # the Sysbox's version. For example, if we need to rebuild the sysbox-deploy-k8s image

--- a/k8s/Makefile
+++ b/k8s/Makefile
@@ -33,7 +33,7 @@ SYSBOX_CE_VER_SEMVER = $(shell echo $(SYSBOX_CE_VER) | cut -d"-" -f1)
 SYSBOX_CE_VER_FULL = $(shell echo $(SYSBOX_CE_VER) | sed '/-[0-9]/!s/.*/&-0/')
 
 # CRIO versions to build.
-CRIO_VERSIONS = v1.26 v1.27 v1.28 v1.29
+CRIO_VERSIONS = v1.26 v1.27 v1.28 v1.29 v1.30
 
 # Patch version is used to track changes to the sysbox-deploy-k8s image not related to
 # the Sysbox's version. For example, if we need to rebuild the sysbox-deploy-k8s image

--- a/k8s/Makefile
+++ b/k8s/Makefile
@@ -33,7 +33,7 @@ SYSBOX_CE_VER_SEMVER = $(shell echo $(SYSBOX_CE_VER) | cut -d"-" -f1)
 SYSBOX_CE_VER_FULL = $(shell echo $(SYSBOX_CE_VER) | sed '/-[0-9]/!s/.*/&-0/')
 
 # CRIO versions to build.
-CRIO_VERSIONS = v1.28 v1.29 v1.30
+CRIO_VERSIONS = v1.27 v1.28 v1.29 v1.30
 
 # Patch version is used to track changes to the sysbox-deploy-k8s image not related to
 # the Sysbox's version. For example, if we need to rebuild the sysbox-deploy-k8s image

--- a/k8s/Makefile
+++ b/k8s/Makefile
@@ -33,7 +33,7 @@ SYSBOX_CE_VER_SEMVER = $(shell echo $(SYSBOX_CE_VER) | cut -d"-" -f1)
 SYSBOX_CE_VER_FULL = $(shell echo $(SYSBOX_CE_VER) | sed '/-[0-9]/!s/.*/&-0/')
 
 # CRIO versions to build.
-CRIO_VERSIONS = v1.26 v1.27 v1.28 v1.29 v1.30
+CRIO_VERSIONS = v1.27 v1.28 v1.29 v1.30
 
 # Patch version is used to track changes to the sysbox-deploy-k8s image not related to
 # the Sysbox's version. For example, if we need to rebuild the sysbox-deploy-k8s image

--- a/k8s/scripts/crio-build.sh
+++ b/k8s/scripts/crio-build.sh
@@ -9,7 +9,7 @@
 # Usage: docker run -v $(shell pwd)/bin:/mnt/results crio-bld
 #
 
-declare -a CRIO_VERSIONS=(v1.26 v1.27 v1.28 v1.29 v1.30)
+declare -a CRIO_VERSIONS=(v1.27 v1.28 v1.29 v1.30)
 
 for ver in ${CRIO_VERSIONS[@]}; do
 	printf "\n*** Building CRI-O ${ver} ... ***\n\n"

--- a/k8s/scripts/crio-build.sh
+++ b/k8s/scripts/crio-build.sh
@@ -9,7 +9,7 @@
 # Usage: docker run -v $(shell pwd)/bin:/mnt/results crio-bld
 #
 
-declare -a CRIO_VERSIONS=(v1.26 v1.27 v1.28 v1.29)
+declare -a CRIO_VERSIONS=(v1.26 v1.27 v1.28 v1.29 v1.30)
 
 for ver in ${CRIO_VERSIONS[@]}; do
 	printf "\n*** Building CRI-O ${ver} ... ***\n\n"

--- a/k8s/scripts/crio-build.sh
+++ b/k8s/scripts/crio-build.sh
@@ -9,7 +9,7 @@
 # Usage: docker run -v $(shell pwd)/bin:/mnt/results crio-bld
 #
 
-declare -a CRIO_VERSIONS=(v1.28 v1.29 v1.30)
+declare -a CRIO_VERSIONS=(v1.27 v1.28 v1.29 v1.30)
 
 for ver in ${CRIO_VERSIONS[@]}; do
 	printf "\n*** Building CRI-O ${ver} ... ***\n\n"

--- a/k8s/scripts/crio-build.sh
+++ b/k8s/scripts/crio-build.sh
@@ -9,7 +9,7 @@
 # Usage: docker run -v $(shell pwd)/bin:/mnt/results crio-bld
 #
 
-declare -a CRIO_VERSIONS=(v1.27 v1.28 v1.29 v1.30)
+declare -a CRIO_VERSIONS=(v1.28 v1.29 v1.30)
 
 for ver in ${CRIO_VERSIONS[@]}; do
 	printf "\n*** Building CRI-O ${ver} ... ***\n\n"

--- a/k8s/scripts/sysbox-deploy-k8s.sh
+++ b/k8s/scripts/sysbox-deploy-k8s.sh
@@ -753,7 +753,8 @@ function is_supported_k8s_version() {
 
 	local ver=$k8s_version
 
-	if [[ "$ver" == "v1.28" ]] ||
+	if [[ "$ver" == "v1.27" ]] ||
+		[[ "$ver" == "v1.28" ]] ||
 		[[ "$ver" == "v1.29" ]] ||
 		[[ "$ver" == "v1.30" ]]; then
 		return
@@ -766,8 +767,7 @@ function is_supported_k8s_version() {
 		[[ "$ver" == "v1.23" ]] ||
 		[[ "$ver" == "v1.24" ]] ||
 		[[ "$ver" == "v1.25" ]] ||
-		[[ "$ver" == "v1.26" ]] ||
-		[[ "$ver" == "v1.27" ]]; then
+		[[ "$ver" == "v1.26" ]]; then
 		echo "Unsupported kubernetes version: $ver (EOL release)."
 	fi
 

--- a/k8s/scripts/sysbox-deploy-k8s.sh
+++ b/k8s/scripts/sysbox-deploy-k8s.sh
@@ -753,9 +753,8 @@ function is_supported_k8s_version() {
 
 	local ver=$k8s_version
 
-	if [[ "$ver" == "v1.27" ]] ||
-		[[ "$ver" == "v1.28" ]] ||
-		[[ "$ver" == "v1.20" ]] ||
+	if [[ "$ver" == "v1.28" ]] ||
+		[[ "$ver" == "v1.29" ]] ||
 		[[ "$ver" == "v1.30" ]]; then
 		return
 	fi
@@ -767,7 +766,8 @@ function is_supported_k8s_version() {
 		[[ "$ver" == "v1.23" ]] ||
 		[[ "$ver" == "v1.24" ]] ||
 		[[ "$ver" == "v1.25" ]] ||
-		[[ "$ver" == "v1.26" ]]; then
+		[[ "$ver" == "v1.26" ]] ||
+		[[ "$ver" == "v1.27" ]]; then
 		echo "Unsupported kubernetes version: $ver (EOL release)."
 	fi
 

--- a/k8s/scripts/sysbox-deploy-k8s.sh
+++ b/k8s/scripts/sysbox-deploy-k8s.sh
@@ -753,8 +753,7 @@ function is_supported_k8s_version() {
 
 	local ver=$k8s_version
 
-	if [[ "$ver" == "v1.26" ]] ||
-		[[ "$ver" == "v1.27" ]] ||
+	if [[ "$ver" == "v1.27" ]] ||
 		[[ "$ver" == "v1.28" ]] ||
 		[[ "$ver" == "v1.20" ]] ||
 		[[ "$ver" == "v1.30" ]]; then
@@ -767,7 +766,8 @@ function is_supported_k8s_version() {
 		[[ "$ver" == "v1.22" ]] ||
 		[[ "$ver" == "v1.23" ]] ||
 		[[ "$ver" == "v1.24" ]] ||
-		[[ "$ver" == "v1.25" ]]; then
+		[[ "$ver" == "v1.25" ]] ||
+		[[ "$ver" == "v1.26" ]]; then
 		echo "Unsupported kubernetes version: $ver (EOL release)."
 	fi
 

--- a/k8s/scripts/sysbox-deploy-k8s.sh
+++ b/k8s/scripts/sysbox-deploy-k8s.sh
@@ -756,7 +756,8 @@ function is_supported_k8s_version() {
 	if [[ "$ver" == "v1.26" ]] ||
 		[[ "$ver" == "v1.27" ]] ||
 		[[ "$ver" == "v1.28" ]] ||
-		[[ "$ver" == "v1.29" ]]; then
+		[[ "$ver" == "v1.20" ]] ||
+		[[ "$ver" == "v1.30" ]]; then
 		return
 	fi
 


### PR DESCRIPTION
Similar to https://github.com/nestybox/sysbox-pkgr/pull/125

[Kubernetes v1.26 is EOL since 2024-02-28 and v1.27 since 2024-07-16](https://kubernetes.io/releases/patch-releases/)

Needed for https://github.com/nestybox/sysbox/issues/814