### PR TITLE
Don't lose the result of the GKE check

### DIFF
--- a/k8s/scripts/sysbox-deploy-k8s.sh
+++ b/k8s/scripts/sysbox-deploy-k8s.sh
@@ -1041,7 +1041,8 @@ function main() {
 		die "invalid arguments"
 	fi
 
-	local is_gke=$(check_is_gke)
+	check_is_gke
+	local is_gke=$?
 
 	# Perform distro-specific adjustments.
 	do_distro_adjustments


### PR DESCRIPTION
Proposed fix for #133.

Since #127 we have been storing and testing the output from `check_is_gke()` but that is always null, which evaluates as "true". After this change we instead store the function's exit status which is what we actually need to test.

```
$ x=$(check_is_gke)
$ y=$?
$ echo $x

$ echo $y
1
````
