### PR TITLE
fix: centos7 (EOL) mirrors update fails

### DIFF
--- a/k8s/Dockerfile.sysbox-ce
+++ b/k8s/Dockerfile.sysbox-ce
@@ -26,6 +26,10 @@ ARG CRIO_V1_27_TAR="cri-o.${SYS_ARCH}.v1.27.0.tar.gz"
 ARG CRIO_V1_28_TAR="cri-o.${SYS_ARCH}.v1.28.0.tar.gz"
 ARG CRIO_V1_29_TAR="cri-o.${SYS_ARCH}.v1.29.0.tar.gz"
 
+# CentOS 7 is EOL: https://stackoverflow.com/a/78693402/13679164
+RUN sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* && \
+    sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
+
 RUN yum install -y curl wget git bc which
 
 RUN curl -Lso /bin/kubectl https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/${SYS_ARCH}/kubectl && \


### PR DESCRIPTION
Solving the following error during yum package installation
```
 => ERROR [ 2/41] RUN yum install -y curl wget git bc which                        0.5s
------                                                                                  
 > [ 2/41] RUN yum install -y curl wget git bc which:                                   
0.318 Loaded plugins: fastestmirror, ovl                                                
0.410 Determining fastest mirrors                                                       
0.439 Could not retrieve mirrorlist http://mirrorlist.centos.org/?release=7&arch=x86_64&repo=os&infra=container error was
0.439 14: curl#6 - "Could not resolve host: mirrorlist.centos.org; Unknown error"
0.441 
0.441 
0.441  One of the configured repositories failed (Unknown),
0.441  and yum doesn't have enough cached data to continue. At this point the only
0.441  safe thing yum can do is fail. There are a few ways to work "fix" this:
0.441 
0.441      1. Contact the upstream for the repository and get them to fix the problem.
0.441 
0.441      2. Reconfigure the baseurl/etc. for the repository, to point to a working
0.441         upstream. This is most often useful if you are using a newer
0.441         distribution release than is supported by the repository (and the
0.441         packages for the previous distribution release still work).
0.441 
0.441      3. Run the command with the repository temporarily disabled
0.441             yum --disablerepo=<repoid> ...
0.441 
0.441      4. Disable the repository permanently, so yum won't use it by default. Yum
0.441         will then just ignore the repository until you permanently enable it
0.441         again or use --enablerepo for temporary usage:
0.441 
0.441             yum-config-manager --disable <repoid>
0.441         or
0.441             subscription-manager repos --disable=<repoid>
0.441 
0.441      5. Configure the failing repository to be skipped, if it is unavailable.
0.441         Note that yum will try to contact the repo. when it runs most commands,
0.441         so will have to try and fail each time (and thus. yum will be be much
0.441         slower). If it is a very temporary problem though, this is often a nice
0.441         compromise:
0.441 
0.441             yum-config-manager --save --setopt=<repoid>.skip_if_unavailable=true
0.441 
0.441 Cannot find a valid baseurl for repo: base/7/x86_64
------
Dockerfile.sysbox-ce:29
--------------------
  27 |     ARG CRIO_V1_30_TAR="cri-o.${SYS_ARCH}.v1.30.0.tar.gz"
  28 |     
  29 | >>> RUN yum install -y curl wget git bc which
  30 |     
  31 |     RUN curl -Lso /bin/kubectl https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/${SYS_ARCH}/kubectl && \
--------------------
ERROR: failed to solve: process "/bin/sh -c yum install -y curl wget git bc which" did not complete successfully: exit code: 1
make: *** [Makefile:127: sysbox-deploy-k8s-image] Error 1

```