### PR TITLE
k8s: Minor adjustment to make 'configfs' kernel module optional

### DIFF
--- a/k8s/scripts/sysbox-installer-helper.sh
+++ b/k8s/scripts/sysbox-installer-helper.sh
@@ -158,9 +158,10 @@ function probe_kernel_mods() {
 		fi
 	fi
 
-	modprobe configfs
-
-	if ! mount | grep -q configfs; then
+	# Ensure that configfs is loaded regardless of the running kernel version. Notice that
+	# we're not enforcing this requirement, and we're simply dumping a log to the user if
+	# configfs is not present.
+	if modprobe configfs && ! mount | grep -q configfs; then
 		echo -e "\nConfigfs kernel module is not loaded. Configfs may be required " \
 			"by certain applications running inside a Sysbox container.\n"
 	fi


### PR DESCRIPTION
I'm simply moving the `modprobe` instruction within an 'if' clause to prevent bash's errexit from bailing out. I verified that it works as expected with a fictitious module not present in my k8s node.