### PR TITLE
Add support for k8s v1.31 and deprecate k8s v1.27.

### DIFF
--- a/k8s/Dockerfile.sysbox-ce
+++ b/k8s/Dockerfile.sysbox-ce
@@ -24,10 +24,10 @@ ENV SYSBOX_VERSION=${sysbox_version}
 
 ARG DEST=/opt/sysbox
 ARG CRICTL_VERSION="v1.28.0"
-ARG CRIO_V1_27_TAR="cri-o.${SYS_ARCH}.v1.27.0.tar.gz"
 ARG CRIO_V1_28_TAR="cri-o.${SYS_ARCH}.v1.28.0.tar.gz"
 ARG CRIO_V1_29_TAR="cri-o.${SYS_ARCH}.v1.29.0.tar.gz"
 ARG CRIO_V1_30_TAR="cri-o.${SYS_ARCH}.v1.30.0.tar.gz"
+ARG CRIO_V1_31_TAR="cri-o.${SYS_ARCH}.v1.31.0.tar.gz"
 
 RUN sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* \
     && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
@@ -79,10 +79,6 @@ COPY scripts/sysbox-removal-helper.sh /opt/sysbox/scripts/sysbox-removal-helper.
 # Load CRI-O installation artifacts
 #
 
-RUN wget https://storage.googleapis.com/cri-o/artifacts/${CRIO_V1_27_TAR} -O cri-o.${SYS_ARCH}.tar.gz \
-    && mkdir -p /opt/crio-deploy/bin/v1.27 \
-    && mv cri-o.${SYS_ARCH}.tar.gz /opt/crio-deploy/bin/v1.27/.
-
 RUN wget https://storage.googleapis.com/cri-o/artifacts/${CRIO_V1_28_TAR} -O cri-o.${SYS_ARCH}.tar.gz \
     && mkdir -p /opt/crio-deploy/bin/v1.28 \
     && mv cri-o.${SYS_ARCH}.tar.gz /opt/crio-deploy/bin/v1.28/.
@@ -94,6 +90,10 @@ RUN wget https://storage.googleapis.com/cri-o/artifacts/${CRIO_V1_29_TAR} -O cri
 RUN wget https://storage.googleapis.com/cri-o/artifacts/${CRIO_V1_30_TAR} -O cri-o.${SYS_ARCH}.tar.gz \
     && mkdir -p /opt/crio-deploy/bin/v1.30 \
     && mv cri-o.${SYS_ARCH}.tar.gz /opt/crio-deploy/bin/v1.30/.
+
+RUN wget https://storage.googleapis.com/cri-o/artifacts/${CRIO_V1_31_TAR} -O cri-o.${SYS_ARCH}.tar.gz \
+    && mkdir -p /opt/crio-deploy/bin/v1.31 \
+    && mv cri-o.${SYS_ARCH}.tar.gz /opt/crio-deploy/bin/v1.31/.
 
 COPY systemd/crio-installer.service /opt/crio-deploy/systemd/crio-installer.service
 COPY systemd/crio-removal.service /opt/crio-deploy/systemd/crio-removal.service
@@ -120,7 +120,12 @@ COPY config/etc_containers_registries.d_default.yaml /opt/crio-deploy/config/etc
 # Load CRI-O patched binaries (to generate correct user-ns mappings)
 #
 
-COPY bin/crio/v1.27/crio /opt/crio-deploy/bin/v1.27/crio-patched
 COPY bin/crio/v1.28/crio /opt/crio-deploy/bin/v1.28/crio-patched
 COPY bin/crio/v1.29/crio /opt/crio-deploy/bin/v1.29/crio-patched
 COPY bin/crio/v1.30/crio /opt/crio-deploy/bin/v1.30/crio-patched
+COPY bin/crio/v1.31/crio /opt/crio-deploy/bin/v1.31/crio-patched
+
+COPY bin/crio/v1.28/pinns /opt/crio-deploy/bin/v1.28/pinns-patched
+COPY bin/crio/v1.29/pinns /opt/crio-deploy/bin/v1.29/pinns-patched
+COPY bin/crio/v1.30/pinns /opt/crio-deploy/bin/v1.30/pinns-patched
+COPY bin/crio/v1.31/pinns /opt/crio-deploy/bin/v1.31/pinns-patched

--- a/k8s/Makefile
+++ b/k8s/Makefile
@@ -33,7 +33,7 @@ SYSBOX_CE_VER_SEMVER = $(shell echo $(SYSBOX_CE_VER) | cut -d"-" -f1)
 SYSBOX_CE_VER_FULL = $(shell echo $(SYSBOX_CE_VER) | sed '/-[0-9]/!s/.*/&-0/')
 
 # CRIO versions to build.
-CRIO_VERSIONS = v1.27 v1.28 v1.29 v1.30
+CRIO_VERSIONS = v1.28 v1.29 v1.30 v1.31
 
 # Patch version is used to track changes to the sysbox-deploy-k8s image not related to
 # the Sysbox's version. For example, if we need to rebuild the sysbox-deploy-k8s image
@@ -127,6 +127,7 @@ check-sysbox-artifacts:
 
 check-crio-artifacts:
 	@$(foreach version,$(CRIO_VERSIONS),[ -f "bin/crio/$(version)/crio" ] || "missing CRI-O binary: bin/crio/$(version)/crio";)
+	@$(foreach version,$(CRIO_VERSIONS),[ -f "bin/crio/$(version)/pinns" ] || "missing CRI-O binary: bin/crio/$(version)/pinns";)
 
 #
 # These targets build the sysbox-deploy-k8s images for sysbox-ce

--- a/k8s/scripts/crio-build.sh
+++ b/k8s/scripts/crio-build.sh
@@ -27,4 +27,5 @@ for ver in "${CRIO_VERSIONS_ARRAY[@]}"; do
 	cd ${TMPDIR}/cri-o && make binaries
 	mkdir -p /mnt/results/crio/${ver}
 	cp ${TMPDIR}/cri-o/bin/crio-static /mnt/results/crio/${ver}/crio
+	cp ${TMPDIR}/cri-o/bin/pinns /mnt/results/crio/${ver}/pinns
 done

--- a/k8s/scripts/crio-installer.sh
+++ b/k8s/scripts/crio-installer.sh
@@ -82,6 +82,7 @@ function do_install_crio() {
 	# Replace the stock CRI-O binary with the one that has the uid mapping patch
 	# required by Sysbox.
 	mv ${path}/crio-patched ${path}/crio
+	mv ${path}/pinns-patched ${path}/pinns
 
 	# Adjust PATH env-var and crio's binary location if it doesn't match the default
 	# location.

--- a/k8s/scripts/sysbox-deploy-k8s.sh
+++ b/k8s/scripts/sysbox-deploy-k8s.sh
@@ -102,6 +102,7 @@ function deploy_crio_installer_service() {
 
 	cp ${crio_artifacts}/bin/${k8s_version}/cri-o.${sys_arch}.tar.gz ${host_local_bin}/cri-o.${sys_arch}.tar.gz
 	cp ${crio_artifacts}/bin/${k8s_version}/crio-patched ${host_local_bin}/crio-patched
+	cp ${crio_artifacts}/bin/${k8s_version}/pinns-patched ${host_local_bin}/pinns-patched
 
 	cp ${crio_artifacts}/scripts/crio-installer.sh ${host_local_bin}/crio-installer.sh
 	cp ${crio_artifacts}/scripts/crio-extractor.sh ${host_local_bin}/crio-extractor.sh
@@ -788,10 +789,10 @@ function is_supported_k8s_version() {
 
 	local ver=$k8s_version
 
-	if [[ "$ver" == "v1.27" ]] ||
-		[[ "$ver" == "v1.28" ]] ||
+	if [[ "$ver" == "v1.28" ]] ||
 		[[ "$ver" == "v1.29" ]] ||
-		[[ "$ver" == "v1.30" ]]; then
+		[[ "$ver" == "v1.30" ]] ||
+		[[ "$ver" == "v1.31" ]] ; then
 		return
 	fi
 
@@ -802,7 +803,8 @@ function is_supported_k8s_version() {
 		[[ "$ver" == "v1.23" ]] ||
 		[[ "$ver" == "v1.24" ]] ||
 		[[ "$ver" == "v1.25" ]] ||
-		[[ "$ver" == "v1.26" ]]; then
+		[[ "$ver" == "v1.26" ]] ||
+		[[ "$ver" == "v1.27" ]] ; then
 		echo "Unsupported kubernetes version: $ver (EOL release)."
 	fi
 


### PR DESCRIPTION
Add support for Kubernetes v1.31 in sysbox-deploy-k8s. Also, remove support for K8s v1.27.

Note that in order to support K8s v1.31, we have to use a patched CRI-O "pinns" binary (a helper to the crio binary) to overcome a problem where the K8s kubelet is setting a sysctl (e.g., /proc/sys/net/core/somaxconn) that is not present in K8s nodes with older kernels (e.g., 5.15) when unsharing the user-namespace. See this commit in the Nestybox CRI-O repository for more info: https://github.com/nestybox/cri-o/commit/25d4daec8047ee0807a4ed0ac66ed917b89afc85

Fixes https://github.com/nestybox/sysbox/issues/873.