### PR TITLE
Support installation on Ubuntu 24.04

### DIFF
--- a/k8s/scripts/sysbox-deploy-k8s.sh
+++ b/k8s/scripts/sysbox-deploy-k8s.sh
@@ -271,7 +271,8 @@ function get_artifacts_dir() {
 
 	local distro=$os_distro_release
 
-	if [[ "$distro" == "ubuntu-22.04" ]] ||
+	if [[ "$distro" == "ubuntu-24.04" ]] ||
+		[[ "$distro" == "ubuntu-22.04" ]] ||
 		[[ "$distro" == "ubuntu-21.10" ]] ||
 		[[ "$distro" == "ubuntu-20.04" ]] ||
 		[[ "$distro" == "ubuntu-18.04" ]] ||
@@ -742,7 +743,8 @@ function is_supported_distro() {
 
 	local distro=$os_distro_release
 
-	if [[ "$distro" == "ubuntu-22.04" ]] ||
+	if [[ "$distro" == "ubuntu-24.04" ]] ||
+		[[ "$distro" == "ubuntu-22.04" ]] ||
 		[[ "$distro" == "ubuntu-21.10" ]] ||
 		[[ "$distro" == "ubuntu-20.04" ]] ||
 		[[ "$distro" == "ubuntu-18.04" ]] ||


### PR DESCRIPTION
I have tested the latest sysbox version on Ubuntu 24.04 by faking the contents of /etc/os-release to allow the installation to proceed. As Ubuntu 24.04 uses kernel 6.8+ there is no need for additional kernel modules. From my testing using sysbox on the 24.04 everything seems to work just fine. I propose the current change to allow installation on this OS.