### PR TITLE
Add support for installing Sysbox on Ubuntu 24.04 (Noble).

### DIFF
--- a/deb/sysbox-ce/sysbox-ce.preinst
+++ b/deb/sysbox-ce/sysbox-ce.preinst
@@ -20,6 +20,8 @@ set -e
 #   |                           |                     |
 #   |   Ubuntu Jammy (22.04)    |        5.15+        |
 #   |                           |                     |
+#   |   Ubuntu Noble (24.04)    |        6.8+         |
+#   |                           |                     |
 #   |   Debian Buster (10)      |        5.5+         |
 #   |                           |                     |
 #   |   Debian Bullseye (11)    |        5.5+         |
@@ -31,6 +33,7 @@ sysbox_support_matrix=(
     ["Ubuntu 20.04"]="5.4"
     ["Ubuntu 21.10"]="5.13"
     ["Ubuntu 22.04"]="5.15"
+    ["Ubuntu 24.04"]="6.8"
     ["Debian 10"]="5.5"
     ["Debian 11"]="5.5"
 )

--- a/deb/sysbox-ee/sysbox-ee.preinst
+++ b/deb/sysbox-ee/sysbox-ee.preinst
@@ -20,6 +20,8 @@ set -e
 #   |                           |                     |
 #   |   Ubuntu Jammy (22.04)    |        5.15+        |
 #   |                           |                     |
+#   |   Ubuntu Noble (24.04)    |        6.8+         |
+#   |                           |                     |
 #   |   Debian Buster (10)      |        5.5+         |
 #   |                           |                     |
 #   |   Debian Bullseye (11)    |        5.5+         |
@@ -31,6 +33,7 @@ sysbox_support_matrix=(
     ["Ubuntu 20.04"]="5.4"
     ["Ubuntu 21.10"]="5.13"
     ["Ubuntu 22.04"]="5.15"
+    ["Ubuntu 24.04"]="6.8"
     ["Debian 10"]="5.5"
     ["Debian 11"]="5.5"
 )


### PR DESCRIPTION
Fixes https://github.com/nestybox/sysbox/issues/822.