### PR TITLE
fix: Detect runtime for RKE2 deployments via kubelet config file

### DIFF
--- a/k8s/scripts/kubelet-config-helper.sh
+++ b/k8s/scripts/kubelet-config-helper.sh
@@ -1255,13 +1255,24 @@ function stop_rke2() {
 
 function get_runtime_kubelet_rke2() {
 	set +e
-	runtime=$(ps -e -o command | egrep kubelet | egrep -o "container-runtime-endpoint=\S*" | cut -d '=' -f2)
-	set -e
+
+	# Try RKE2 v1.32+ config file first
+    local rke2_config="/var/lib/rancher/rke2/agent/etc/kubelet.conf.d/00-rke2-defaults.conf"
+    if [[ -f "$rke2_config" ]]; then
+        runtime=$(grep "^containerRuntimeEndpoint:" "$rke2_config" | awk '{print $2}')
+    fi
+
+    # Fallback to legacy kubelet command line parameter for older versions
+    if [[ -z "$runtime" ]]; then
+        runtime=$(ps -e -o command | grep kubelet | grep -o "container-runtime-endpoint=\S*" | cut -d '=' -f2)
+    fi
 
 	# If runtime is unknown, assume it's Docker
 	if [[ ${runtime} == "" ]]; then
 		runtime="unix:///var/run/dockershim.sock"
 	fi
+
+	set -e
 }
 
 function config_kubelet_rke2() {

--- a/k8s/scripts/kubelet-unconfig-helper.sh
+++ b/k8s/scripts/kubelet-unconfig-helper.sh
@@ -345,13 +345,24 @@ function revert_kubelet_config_rke2() {
 
 function get_runtime_kubelet_rke2() {
 	set +e
-	runtime=$(ps -e -o command | egrep kubelet | egrep -o "container-runtime-endpoint=\S*" | cut -d '=' -f2)
-	set -e
 
-	# If runtime is unknown, assume it's Docker.
+	# Try RKE2 v1.32+ config file first
+    local rke2_config="/var/lib/rancher/rke2/agent/etc/kubelet.conf.d/00-rke2-defaults.conf"
+    if [[ -f "$rke2_config" ]]; then
+        runtime=$(grep "^containerRuntimeEndpoint:" "$rke2_config" | awk '{print $2}')
+    fi
+
+    # Fallback to legacy kubelet command line parameter for older versions
+    if [[ -z "$runtime" ]]; then
+        runtime=$(ps -e -o command | grep kubelet | grep -o "container-runtime-endpoint=\S*" | cut -d '=' -f2)
+    fi
+
+	# If runtime is unknown, assume it's Docker
 	if [[ ${runtime} == "" ]]; then
 		runtime="unix:///var/run/dockershim.sock"
 	fi
+
+	set -e
 }
 
 function do_unconfig_kubelet_rke2() {


### PR DESCRIPTION
Since kubernetes v1.32 the kubelet configuration for RKE2 clusters is done via a config file [1]. This means that there is no longer a 'container-runtime-endpoint' flag to parse, currently resulting in errors when trying to install sysbox on such a cluster. This commit implements the recommended solution from [2].

[1]: https://docs.rke2.io/install/configuration#kubelet-configuration
[2]: https://github.com/nestybox/sysbox/issues/974#issue-3623262775

Fixes https://github.com/nestybox/sysbox/issues/974