### PR TITLE
Fail if containerd version cannot be retrieved.

### DIFF
--- a/k8s/scripts/sysbox-deploy-k8s.sh
+++ b/k8s/scripts/sysbox-deploy-k8s.sh
@@ -996,7 +996,10 @@ function is_containerd_with_userns() {
 	# to use the alternative runtime, but containers within the sandbox still use
 	# the default runc runtime.
 
-	local runtime_version=$(kubectl get node $NODE_NAME -o jsonpath='{.status.nodeInfo.containerRuntimeVersion}')
+	local runtime_version
+	if ! runtime_version=$(kubectl get node $NODE_NAME -o jsonpath='{.status.nodeInfo.containerRuntimeVersion}'); then
+		die "Failed to get containerd version"
+	fi
 
 	# Check if it's containerd
 	if ! echo "$runtime_version" | grep -q "containerd://"; then


### PR DESCRIPTION
Do not silently fail when retrieving the containerd version.

We ran into this exact issue: sysbox silently assumed containerd did not support user namespaces because of a transient connection issue when fetching the containerd version.

Because of this the node unusable as sysbox-runc is not configured in containerd, which makes the node is unusable.