### PR TITLE
k8s: ship sysbox-runc as a containerd drop-in for k3s / RKE2

### DIFF
--- a/k8s/Dockerfile.sysbox-ce
+++ b/k8s/Dockerfile.sysbox-ce
@@ -75,7 +75,7 @@ COPY scripts/sysbox-deploy-k8s.sh /opt/sysbox/scripts/sysbox-deploy-k8s.sh
 COPY scripts/sysbox-installer-helper.sh /opt/sysbox/scripts/sysbox-installer-helper.sh
 COPY scripts/sysbox-removal-helper.sh /opt/sysbox/scripts/sysbox-removal-helper.sh
 
-COPY config/containerd-sysbox-dropin.toml.tmpl /opt/sysbox/config/containerd-sysbox-dropin.toml.tmpl
+COPY config/containerd-sysbox-dropin.toml /opt/sysbox/config/containerd-sysbox-dropin.toml
 
 #
 # Load CRI-O installation artifacts

--- a/k8s/Dockerfile.sysbox-ce
+++ b/k8s/Dockerfile.sysbox-ce
@@ -75,6 +75,8 @@ COPY scripts/sysbox-deploy-k8s.sh /opt/sysbox/scripts/sysbox-deploy-k8s.sh
 COPY scripts/sysbox-installer-helper.sh /opt/sysbox/scripts/sysbox-installer-helper.sh
 COPY scripts/sysbox-removal-helper.sh /opt/sysbox/scripts/sysbox-removal-helper.sh
 
+COPY config/containerd-sysbox-dropin.toml.tmpl /opt/sysbox/config/containerd-sysbox-dropin.toml.tmpl
+
 #
 # Load CRI-O installation artifacts
 #

--- a/k8s/config/containerd-sysbox-dropin.toml
+++ b/k8s/config/containerd-sysbox-dropin.toml
@@ -1,5 +1,5 @@
 [plugins."io.containerd.cri.v1.runtime".containerd.runtimes.sysbox-runc]
   runtime_type = "io.containerd.runc.v2"
   [plugins."io.containerd.cri.v1.runtime".containerd.runtimes.sysbox-runc.options]
-    BinaryName = "@SYSBOX_RUNC_PATH@"
+    BinaryName = "/usr/bin/sysbox-runc"
     SystemdCgroup = true

--- a/k8s/config/containerd-sysbox-dropin.toml.tmpl
+++ b/k8s/config/containerd-sysbox-dropin.toml.tmpl
@@ -1,0 +1,5 @@
+[plugins."io.containerd.cri.v1.runtime".containerd.runtimes.sysbox-runc]
+  runtime_type = "io.containerd.runc.v2"
+  [plugins."io.containerd.cri.v1.runtime".containerd.runtimes.sysbox-runc.options]
+    BinaryName = "@SYSBOX_RUNC_PATH@"
+    SystemdCgroup = true

--- a/k8s/scripts/sysbox-deploy-k8s.sh
+++ b/k8s/scripts/sysbox-deploy-k8s.sh
@@ -39,8 +39,10 @@ sysbox_version=$(echo "$SYSBOX_VERSION" | sed '/-[0-9]/!s/.*/&-0/')
 sysbox_artifacts="/opt/sysbox"
 crio_artifacts="/opt/crio-deploy"
 
-# Template for the containerd drop-in used on k3s / RKE2.
-containerd_sysbox_dropin_tmpl="${sysbox_artifacts}/config/containerd-sysbox-dropin.toml.tmpl"
+# Containerd drop-in used on k3s / RKE2. Ships with /usr/bin/sysbox-runc; on
+# Flatcar do_distro_adjustments() rewrites this artifact to /opt/bin/sysbox-runc
+# up-front, so the install path can copy it verbatim.
+containerd_sysbox_dropin_src="${sysbox_artifacts}/config/containerd-sysbox-dropin.toml"
 
 # The daemonset spec will set up these mounts.
 host_systemd="/mnt/host/lib/systemd/system"
@@ -720,18 +722,16 @@ function restart_container_runtime() {
 # untouched. Uses the containerd 2.x config-v3 plugin key.
 function write_containerd_sysbox_dropin() {
 	local dropin_dir="$1"
-	local sysbox_runc_path="$2"
 	local dropin_file="${dropin_dir}/sysbox.toml"
 
-	if [ ! -f "${containerd_sysbox_dropin_tmpl}" ]; then
-		echo "Error: containerd drop-in template not found at ${containerd_sysbox_dropin_tmpl}"
+	if [ ! -f "${containerd_sysbox_dropin_src}" ]; then
+		echo "Error: containerd drop-in source not found at ${containerd_sysbox_dropin_src}"
 		return 1
 	fi
 
 	echo "Writing Sysbox containerd drop-in to ${dropin_file} ..."
 	mkdir -p "${dropin_dir}"
-	sed "s|@SYSBOX_RUNC_PATH@|${sysbox_runc_path}|g" \
-		"${containerd_sysbox_dropin_tmpl}" >"${dropin_file}"
+	cp "${containerd_sysbox_dropin_src}" "${dropin_file}"
 }
 
 function config_containerd_for_sysbox() {
@@ -750,7 +750,7 @@ function config_containerd_for_sysbox() {
 	local dropin_dir
 	dropin_dir="$(k8s_containerd_dropin_dir)"
 	if [ -n "${dropin_dir}" ]; then
-		write_containerd_sysbox_dropin "${dropin_dir}" "${sysbox_runc_path}"
+		write_containerd_sysbox_dropin "${dropin_dir}"
 		echo "Restarting container runtime to apply changes ..."
 		restart_container_runtime
 		return

--- a/k8s/scripts/sysbox-deploy-k8s.sh
+++ b/k8s/scripts/sysbox-deploy-k8s.sh
@@ -39,6 +39,9 @@ sysbox_version=$(echo "$SYSBOX_VERSION" | sed '/-[0-9]/!s/.*/&-0/')
 sysbox_artifacts="/opt/sysbox"
 crio_artifacts="/opt/crio-deploy"
 
+# Template for the containerd drop-in used on k3s / RKE2.
+containerd_sysbox_dropin_tmpl="${sysbox_artifacts}/config/containerd-sysbox-dropin.toml.tmpl"
+
 # The daemonset spec will set up these mounts.
 host_systemd="/mnt/host/lib/systemd/system"
 host_sysctl="/mnt/host/lib/sysctl.d"
@@ -671,18 +674,91 @@ function unconfig_crio_for_sysbox() {
 # Containerd Configuration Functions
 #
 
+# Returns the name of the k3s / RKE2 distribution that owns containerd on
+# this node ("k3s" or "rke2"), or empty if the node runs vanilla containerd.
+# Detection is done via systemd because the kubelet-reported runtime version
+# string ("containerd://X.Y.Z-k3sN") cannot distinguish k3s from rke2.
+function k8s_dist_owning_containerd() {
+	if systemctl is-active --quiet rke2-agent || systemctl is-active --quiet rke2-server; then
+		echo "rke2"
+	elif systemctl is-active --quiet k3s-agent || systemctl is-active --quiet k3s; then
+		echo "k3s"
+	fi
+}
+
+# Returns the containerd config-v3 drop-in directory used by k3s / RKE2 on
+# this node, or empty for vanilla containerd. k3s and RKE2 with containerd
+# 2.x read all *.toml files in this directory and merge them on top of the
+# generated base config, so shipping the Sysbox runtime as a standalone
+# drop-in avoids overwriting the distro's generated config.toml.
+function k8s_containerd_dropin_dir() {
+	local dist
+	dist="$(k8s_dist_owning_containerd)"
+	[ -z "${dist}" ] && return
+	echo "${host_var_lib}/rancher/${dist}/agent/etc/containerd/config-v3.toml.d"
+}
+
+# Restart whichever service owns containerd on this node. For k3s / RKE2 the
+# wrapper service must be restarted because it manages an embedded containerd;
+# vanilla nodes restart containerd directly.
+function restart_container_runtime() {
+	if systemctl is-active --quiet rke2-agent; then
+		systemctl restart rke2-agent
+	elif systemctl is-active --quiet rke2-server; then
+		systemctl restart rke2-server
+	elif systemctl is-active --quiet k3s-agent; then
+		systemctl restart k3s-agent
+	elif systemctl is-active --quiet k3s; then
+		systemctl restart k3s
+	else
+		systemctl restart containerd
+	fi
+}
+
+# Write the Sysbox containerd drop-in used by k3s / RKE2. Emits only the
+# sysbox-runc runtime block so the distro's generated base config is left
+# untouched. Uses the containerd 2.x config-v3 plugin key.
+function write_containerd_sysbox_dropin() {
+	local dropin_dir="$1"
+	local sysbox_runc_path="$2"
+	local dropin_file="${dropin_dir}/sysbox.toml"
+
+	if [ ! -f "${containerd_sysbox_dropin_tmpl}" ]; then
+		echo "Error: containerd drop-in template not found at ${containerd_sysbox_dropin_tmpl}"
+		return 1
+	fi
+
+	echo "Writing Sysbox containerd drop-in to ${dropin_file} ..."
+	mkdir -p "${dropin_dir}"
+	sed "s|@SYSBOX_RUNC_PATH@|${sysbox_runc_path}|g" \
+		"${containerd_sysbox_dropin_tmpl}" >"${dropin_file}"
+}
+
 function config_containerd_for_sysbox() {
 	echo "Adding Sysbox to containerd config ..."
-
-	# Backup the original containerd config if not already backed up
-	if [ ! -f "${host_containerd_conf_file_backup}" ]; then
-		cp "${host_containerd_conf_file}" "${host_containerd_conf_file_backup}"
-	fi
 
 	# Determine the correct sysbox-runc path
 	local sysbox_runc_path="/usr/bin/sysbox-runc"
 	if host_flatcar_distro; then
 		sysbox_runc_path="/opt/bin/sysbox-runc"
+	fi
+
+	# k3s / RKE2 ship containerd with a generated config.toml that is
+	# rewritten on every restart; the supported extension point is the
+	# config-v3 drop-in directory. Use it when present and skip the
+	# /etc/containerd/config.toml path entirely.
+	local dropin_dir
+	dropin_dir="$(k8s_containerd_dropin_dir)"
+	if [ -n "${dropin_dir}" ]; then
+		write_containerd_sysbox_dropin "${dropin_dir}" "${sysbox_runc_path}"
+		echo "Restarting container runtime to apply changes ..."
+		restart_container_runtime
+		return
+	fi
+
+	# Backup the original containerd config if not already backed up
+	if [ ! -f "${host_containerd_conf_file_backup}" ]; then
+		cp "${host_containerd_conf_file}" "${host_containerd_conf_file_backup}"
 	fi
 
 	# Check if sysbox-runc runtime section already exists
@@ -713,6 +789,22 @@ function config_containerd_for_sysbox() {
 
 function unconfig_containerd_for_sysbox() {
 	echo "Removing Sysbox from containerd config ..."
+
+	# k3s / RKE2: just delete the drop-in we created.
+	local dropin_dir
+	dropin_dir="$(k8s_containerd_dropin_dir)"
+	if [ -n "${dropin_dir}" ]; then
+		local dropin_file="${dropin_dir}/sysbox.toml"
+		if [ -f "${dropin_file}" ]; then
+			echo "Removing Sysbox containerd drop-in ${dropin_file} ..."
+			rm -f "${dropin_file}"
+			echo "Restarting container runtime to apply changes ..."
+			restart_container_runtime
+		else
+			echo "sysbox-runc drop-in not found"
+		fi
+		return
+	fi
 
 	if [ -f "${host_containerd_conf_file}" ]; then
 		# Check if sysbox-runc runtime configuration exists


### PR DESCRIPTION
### Summary

The Sysbox v0.7.0 deb already ships everything needed to run sysbox-runc pods with `hostUsers: false` on K8s + containerd v2 -- the maintainer confirmed as much in [nestybox/sysbox-runc#109](https://github.com/nestybox/sysbox-runc/pull/109#issuecomment-3994778839) ("Sysbox v0.7.0 supports K8s pods with user-namespaces"). Verified empirically: the v0.7.0 deb's `sysbox-runc` (commit `a4dd414f`) carries the `features` subcommand from [sysbox-runc#106](https://github.com/nestybox/sysbox-runc/pull/106), which is what advertises userns support to containerd 2.x's runtime introspection (`internal/cri/server/service.go::supportsCRIUserns`).

On k3s / RKE2 the deploy script cannot actually land that binary stack though, because the `dasel`-based edit of `/etc/containerd/config.toml` is wiped on every agent restart (k3s and RKE2 regenerate the file from a template). This PR writes the sysbox-runc runtime block as a `config-v3.toml.d` drop-in instead -- the supported extension point on those distros.

### Problem

`sysbox-deploy-k8s` fails on k3s / RKE2 with containerd v2 ([sysbox#1000](https://github.com/nestybox/sysbox/issues/1000)):

```
Detected containerd version 2.1.5-k3s1.
Adding Sysbox to containerd config ...
cp: cannot stat '/mnt/host/etc/containerd/config.toml': No such file or directory
```

Even when the file is created, k3s/RKE2 regenerate it on the next agent restart so any edits are dropped silently -- the user's runtime config disappears between reboots.

### Fix

- Detect k3s / RKE2 via systemd (`k8s_dist_owning_containerd`).
- Write `sysbox.toml` to the distro's `config-v3.toml.d` directory: `/var/lib/rancher/<dist>/agent/etc/containerd/config-v3.toml.d/sysbox.toml`.
- The drop-in body lives as a static TOML next to the other `k8s/config/*` artifacts. `BinaryName` is hard-coded to `/usr/bin/sysbox-runc` (the only path the installer ever writes for sysbox-CE on non-Flatcar nodes).
- Vanilla containerd nodes keep the existing `dasel`-based edit path unchanged.

### Why drop-in, not path redirect

| Approach | Pro | Con |
|---|---|---|
| Redirect `host_containerd_conf_file` to `/var/lib/rancher/<dist>/.../config.toml` | Smaller diff | Wiped on every agent restart; works against k3s/RKE2's supported extension model |
| Drop-in into `config-v3.toml.d` (this PR) | Survives regeneration; matches documented extension point | Slightly more code (distro detection + restart-service dispatcher) |

### Note on `SupportsUserns`

This PR does not set `SupportsUserns = true` on the runtime entry. The key is not a field on containerd's `Runtime` config struct (`internal/cri/config/config.go`) and is silently discarded by the TOML decoder -- empirically verified on containerd 2.2.3-k3s1 (no behavioural difference with or without the line; net-ns ownership and OCI spec `user.path` are identical). The real userns gating mechanism is the `<runtime> features` subcommand result, which sysbox-runc already handles since [nestybox/sysbox-runc#106](https://github.com/nestybox/sysbox-runc/pull/106) and which is present in the v0.7.0 deb.

### Test plan

Verified on Flatcar 4593.2.1 + RKE2 v1.36.0+rke2r1 + containerd 2.2.3-k3s1 + Cilium CNI, with stock v0.7.0 deb binaries (no out-of-tree patches, extracted directly from the sysbox-deploy-k8s container image: sysbox-runc commit `a4dd414f`, sysbox-fs commit `b70bd38b`, sysbox-mgr commit `aa8f237c`):

| Scenario | Result |
|---|---|
| Install via daemonset on RKE2 | Drop-in written at `/var/lib/rancher/rke2/agent/etc/containerd/config-v3.toml.d/sysbox.toml`; survives `rke2-agent` restart |
| Uninstall | Drop-in removed cleanly |
| `runtimeClassName: sysbox-runc` + `hostUsers: false` (alpine sleep) | Running. `uid_map` shows K8s-allocated level-1 range; sysfs/proc mounted; sysbox-fs FUSE serves `/proc/sys`; binfmt_misc visible |
| `runtimeClassName: sysbox-runc` + `hostUsers: false` + docker:dind | Running. Inner dockerd starts, pulls `alpine:3.19`, inner container gets bridge IP, outbound to `1.1.1.1` succeeds |

This matches the maintainer's claim in nestybox/sysbox-runc#109 that v0.7.0 supports `hostUsers: false` pods -- but only once the deploy script actually lands the runtime registration. This PR is what makes that happen on k3s / RKE2.

The vanilla containerd dasel path was not exercised in the manual test; please flag if additional verification is wanted.

### Scope

- `hostUsers: true` (the Pod-spec default) still fails at sysfs EPERM on this stack with any sysbox-runc version. The maintainer's position in nestybox/sysbox-runc#109 is that `hostUsers: false` is the supported path; this PR follows that direction.
- Flatcar 4593+ (kernel 6.x) + Sysbox-CE: separate companion PR [#153](https://github.com/nestybox/sysbox-pkgr/pull/153), relates to [nestybox/sysbox#995](https://github.com/nestybox/sysbox/issues/995).
- K8s v1.36 allowlist extension: separate, tracked in nestybox/sysbox#961.