### PR TITLE
k8s: support Sysbox-CE on Flatcar 4593+ (kernel 6.x)

### DIFF
--- a/k8s/Dockerfile.sysbox-ce
+++ b/k8s/Dockerfile.sysbox-ce
@@ -75,7 +75,7 @@ COPY scripts/sysbox-deploy-k8s.sh /opt/sysbox/scripts/sysbox-deploy-k8s.sh
 COPY scripts/sysbox-installer-helper.sh /opt/sysbox/scripts/sysbox-installer-helper.sh
 COPY scripts/sysbox-removal-helper.sh /opt/sysbox/scripts/sysbox-removal-helper.sh
 
-COPY config/containerd-sysbox-dropin.toml.tmpl /opt/sysbox/config/containerd-sysbox-dropin.toml.tmpl
+COPY config/containerd-sysbox-dropin.toml /opt/sysbox/config/containerd-sysbox-dropin.toml
 
 #
 # Load CRI-O installation artifacts

--- a/k8s/Dockerfile.sysbox-ce
+++ b/k8s/Dockerfile.sysbox-ce
@@ -75,6 +75,8 @@ COPY scripts/sysbox-deploy-k8s.sh /opt/sysbox/scripts/sysbox-deploy-k8s.sh
 COPY scripts/sysbox-installer-helper.sh /opt/sysbox/scripts/sysbox-installer-helper.sh
 COPY scripts/sysbox-removal-helper.sh /opt/sysbox/scripts/sysbox-removal-helper.sh
 
+COPY config/containerd-sysbox-dropin.toml.tmpl /opt/sysbox/config/containerd-sysbox-dropin.toml.tmpl
+
 #
 # Load CRI-O installation artifacts
 #

--- a/k8s/config/containerd-sysbox-dropin.toml
+++ b/k8s/config/containerd-sysbox-dropin.toml
@@ -1,5 +1,5 @@
 [plugins."io.containerd.cri.v1.runtime".containerd.runtimes.sysbox-runc]
   runtime_type = "io.containerd.runc.v2"
   [plugins."io.containerd.cri.v1.runtime".containerd.runtimes.sysbox-runc.options]
-    BinaryName = "@SYSBOX_RUNC_PATH@"
+    BinaryName = "/usr/bin/sysbox-runc"
     SystemdCgroup = true

--- a/k8s/config/containerd-sysbox-dropin.toml.tmpl
+++ b/k8s/config/containerd-sysbox-dropin.toml.tmpl
@@ -1,0 +1,5 @@
+[plugins."io.containerd.cri.v1.runtime".containerd.runtimes.sysbox-runc]
+  runtime_type = "io.containerd.runc.v2"
+  [plugins."io.containerd.cri.v1.runtime".containerd.runtimes.sysbox-runc.options]
+    BinaryName = "@SYSBOX_RUNC_PATH@"
+    SystemdCgroup = true

--- a/k8s/scripts/sysbox-deploy-k8s.sh
+++ b/k8s/scripts/sysbox-deploy-k8s.sh
@@ -39,8 +39,10 @@ sysbox_version=$(echo "$SYSBOX_VERSION" | sed '/-[0-9]/!s/.*/&-0/')
 sysbox_artifacts="/opt/sysbox"
 crio_artifacts="/opt/crio-deploy"
 
-# Template for the containerd drop-in used on k3s / RKE2.
-containerd_sysbox_dropin_tmpl="${sysbox_artifacts}/config/containerd-sysbox-dropin.toml.tmpl"
+# Containerd drop-in used on k3s / RKE2. Ships with /usr/bin/sysbox-runc; on
+# Flatcar do_distro_adjustments() rewrites this artifact to /opt/bin/sysbox-runc
+# up-front, so the install path can copy it verbatim.
+containerd_sysbox_dropin_src="${sysbox_artifacts}/config/containerd-sysbox-dropin.toml"
 
 # The daemonset spec will set up these mounts.
 host_systemd="/mnt/host/lib/systemd/system"
@@ -720,18 +722,16 @@ function restart_container_runtime() {
 # untouched. Uses the containerd 2.x config-v3 plugin key.
 function write_containerd_sysbox_dropin() {
 	local dropin_dir="$1"
-	local sysbox_runc_path="$2"
 	local dropin_file="${dropin_dir}/sysbox.toml"
 
-	if [ ! -f "${containerd_sysbox_dropin_tmpl}" ]; then
-		echo "Error: containerd drop-in template not found at ${containerd_sysbox_dropin_tmpl}"
+	if [ ! -f "${containerd_sysbox_dropin_src}" ]; then
+		echo "Error: containerd drop-in source not found at ${containerd_sysbox_dropin_src}"
 		return 1
 	fi
 
 	echo "Writing Sysbox containerd drop-in to ${dropin_file} ..."
 	mkdir -p "${dropin_dir}"
-	sed "s|@SYSBOX_RUNC_PATH@|${sysbox_runc_path}|g" \
-		"${containerd_sysbox_dropin_tmpl}" >"${dropin_file}"
+	cp "${containerd_sysbox_dropin_src}" "${dropin_file}"
 }
 
 function config_containerd_for_sysbox() {
@@ -750,7 +750,7 @@ function config_containerd_for_sysbox() {
 	local dropin_dir
 	dropin_dir="$(k8s_containerd_dropin_dir)"
 	if [ -n "${dropin_dir}" ]; then
-		write_containerd_sysbox_dropin "${dropin_dir}" "${sysbox_runc_path}"
+		write_containerd_sysbox_dropin "${dropin_dir}"
 		echo "Restarting container runtime to apply changes ..."
 		restart_container_runtime
 		return

--- a/k8s/scripts/sysbox-deploy-k8s.sh
+++ b/k8s/scripts/sysbox-deploy-k8s.sh
@@ -39,6 +39,9 @@ sysbox_version=$(echo "$SYSBOX_VERSION" | sed '/-[0-9]/!s/.*/&-0/')
 sysbox_artifacts="/opt/sysbox"
 crio_artifacts="/opt/crio-deploy"
 
+# Template for the containerd drop-in used on k3s / RKE2.
+containerd_sysbox_dropin_tmpl="${sysbox_artifacts}/config/containerd-sysbox-dropin.toml.tmpl"
+
 # The daemonset spec will set up these mounts.
 host_systemd="/mnt/host/lib/systemd/system"
 host_sysctl="/mnt/host/lib/sysctl.d"
@@ -671,18 +674,91 @@ function unconfig_crio_for_sysbox() {
 # Containerd Configuration Functions
 #
 
+# Returns the name of the k3s / RKE2 distribution that owns containerd on
+# this node ("k3s" or "rke2"), or empty if the node runs vanilla containerd.
+# Detection is done via systemd because the kubelet-reported runtime version
+# string ("containerd://X.Y.Z-k3sN") cannot distinguish k3s from rke2.
+function k8s_dist_owning_containerd() {
+	if systemctl is-active --quiet rke2-agent || systemctl is-active --quiet rke2-server; then
+		echo "rke2"
+	elif systemctl is-active --quiet k3s-agent || systemctl is-active --quiet k3s; then
+		echo "k3s"
+	fi
+}
+
+# Returns the containerd config-v3 drop-in directory used by k3s / RKE2 on
+# this node, or empty for vanilla containerd. k3s and RKE2 with containerd
+# 2.x read all *.toml files in this directory and merge them on top of the
+# generated base config, so shipping the Sysbox runtime as a standalone
+# drop-in avoids overwriting the distro's generated config.toml.
+function k8s_containerd_dropin_dir() {
+	local dist
+	dist="$(k8s_dist_owning_containerd)"
+	[ -z "${dist}" ] && return
+	echo "${host_var_lib}/rancher/${dist}/agent/etc/containerd/config-v3.toml.d"
+}
+
+# Restart whichever service owns containerd on this node. For k3s / RKE2 the
+# wrapper service must be restarted because it manages an embedded containerd;
+# vanilla nodes restart containerd directly.
+function restart_container_runtime() {
+	if systemctl is-active --quiet rke2-agent; then
+		systemctl restart rke2-agent
+	elif systemctl is-active --quiet rke2-server; then
+		systemctl restart rke2-server
+	elif systemctl is-active --quiet k3s-agent; then
+		systemctl restart k3s-agent
+	elif systemctl is-active --quiet k3s; then
+		systemctl restart k3s
+	else
+		systemctl restart containerd
+	fi
+}
+
+# Write the Sysbox containerd drop-in used by k3s / RKE2. Emits only the
+# sysbox-runc runtime block so the distro's generated base config is left
+# untouched. Uses the containerd 2.x config-v3 plugin key.
+function write_containerd_sysbox_dropin() {
+	local dropin_dir="$1"
+	local sysbox_runc_path="$2"
+	local dropin_file="${dropin_dir}/sysbox.toml"
+
+	if [ ! -f "${containerd_sysbox_dropin_tmpl}" ]; then
+		echo "Error: containerd drop-in template not found at ${containerd_sysbox_dropin_tmpl}"
+		return 1
+	fi
+
+	echo "Writing Sysbox containerd drop-in to ${dropin_file} ..."
+	mkdir -p "${dropin_dir}"
+	sed "s|@SYSBOX_RUNC_PATH@|${sysbox_runc_path}|g" \
+		"${containerd_sysbox_dropin_tmpl}" >"${dropin_file}"
+}
+
 function config_containerd_for_sysbox() {
 	echo "Adding Sysbox to containerd config ..."
-
-	# Backup the original containerd config if not already backed up
-	if [ ! -f "${host_containerd_conf_file_backup}" ]; then
-		cp "${host_containerd_conf_file}" "${host_containerd_conf_file_backup}"
-	fi
 
 	# Determine the correct sysbox-runc path
 	local sysbox_runc_path="/usr/bin/sysbox-runc"
 	if host_flatcar_distro; then
 		sysbox_runc_path="/opt/bin/sysbox-runc"
+	fi
+
+	# k3s / RKE2 ship containerd with a generated config.toml that is
+	# rewritten on every restart; the supported extension point is the
+	# config-v3 drop-in directory. Use it when present and skip the
+	# /etc/containerd/config.toml path entirely.
+	local dropin_dir
+	dropin_dir="$(k8s_containerd_dropin_dir)"
+	if [ -n "${dropin_dir}" ]; then
+		write_containerd_sysbox_dropin "${dropin_dir}" "${sysbox_runc_path}"
+		echo "Restarting container runtime to apply changes ..."
+		restart_container_runtime
+		return
+	fi
+
+	# Backup the original containerd config if not already backed up
+	if [ ! -f "${host_containerd_conf_file_backup}" ]; then
+		cp "${host_containerd_conf_file}" "${host_containerd_conf_file_backup}"
 	fi
 
 	# Check if sysbox-runc runtime section already exists
@@ -713,6 +789,22 @@ function config_containerd_for_sysbox() {
 
 function unconfig_containerd_for_sysbox() {
 	echo "Removing Sysbox from containerd config ..."
+
+	# k3s / RKE2: just delete the drop-in we created.
+	local dropin_dir
+	dropin_dir="$(k8s_containerd_dropin_dir)"
+	if [ -n "${dropin_dir}" ]; then
+		local dropin_file="${dropin_dir}/sysbox.toml"
+		if [ -f "${dropin_file}" ]; then
+			echo "Removing Sysbox containerd drop-in ${dropin_file} ..."
+			rm -f "${dropin_file}"
+			echo "Restarting container runtime to apply changes ..."
+			restart_container_runtime
+		else
+			echo "sysbox-runc drop-in not found"
+		fi
+		return
+	fi
 
 	if [ -f "${host_containerd_conf_file}" ]; then
 		# Check if sysbox-runc runtime configuration exists

--- a/k8s/scripts/sysbox-deploy-k8s.sh
+++ b/k8s/scripts/sysbox-deploy-k8s.sh
@@ -1276,11 +1276,6 @@ function do_distro_adjustments() {
 		return
 	fi
 
-	# Ensure that Flatcar installation proceeds only in Sysbox-EE case.
-	if [[ ${sysbox_edition} != "Sysbox-EE" ]]; then
-		die "Flatcar OS distribution is only supported on Sysbox Enterprise-Edition. Exiting ..."
-	fi
-
 	# Adjust global vars.
 	host_bin="/mnt/host/opt/bin"
 	host_local_bin="/mnt/host/opt/local/bin"
@@ -1310,6 +1305,9 @@ function do_distro_adjustments() {
 	sed -i '/^ExecStart=/ s@/usr/bin@/opt/bin@g' ${sysbox_artifacts}/systemd/sysbox.service
 	sed -i '/^ExecStart=/ s@/usr/local/bin@/opt/local/bin@g' ${sysbox_artifacts}/systemd/sysbox-installer-helper.service
 	sed -i '/^ExecStart=/ s@/usr/local/bin@/opt/local/bin@g' ${sysbox_artifacts}/systemd/sysbox-removal-helper.service
+
+	# Adjust the containerd drop-in used on k3s / RKE2.
+	sed -i 's@/usr/bin/sysbox-runc@/opt/bin/sysbox-runc@' ${sysbox_artifacts}/config/containerd-sysbox-dropin.toml
 
 	# Sysctl adjustments.
 	sed -i '/^kernel.unprivileged_userns_clone/ s/^#*/# /' ${sysbox_artifacts}/systemd/99-sysbox-sysctl.conf

--- a/k8s/scripts/sysbox-deploy-k8s.sh
+++ b/k8s/scripts/sysbox-deploy-k8s.sh
@@ -287,8 +287,16 @@ function get_artifacts_dir() {
 		[[ "$distro" =~ "debian" ]]; then
 		artifacts_dir="${sysbox_artifacts}/bin/generic"
 	elif [[ "$distro" =~ "flatcar" ]]; then
-		local release=$(echo $distro | cut -d"-" -f2)
-		artifacts_dir="${sysbox_artifacts}/bin/flatcar-${release}"
+		if [[ ${sysbox_edition} == "Sysbox" ]]; then
+			# Sysbox-CE (sysbox_edition="Sysbox") ships only the generic
+			# binaries; Flatcar 4593+ runs a 6.x kernel with idmap mounts so
+			# the EE-only shiftfs build that normally lives under
+			# bin/flatcar-<release> is not required.
+			artifacts_dir="${sysbox_artifacts}/bin/generic"
+		else
+			local release=$(echo $distro | cut -d"-" -f2)
+			artifacts_dir="${sysbox_artifacts}/bin/flatcar-${release}"
+		fi
 	fi
 
 	echo $artifacts_dir
@@ -498,7 +506,16 @@ function install_sysbox_deps() {
 	fi
 
 	if host_flatcar_distro; then
-		install_sysbox_deps_flatcar
+		# Mirror the non-Flatcar branch: only attempt to install shiftfs when
+		# the host kernel is in the supported range. Flatcar 4593+ ships
+		# kernel 6.x where shiftfs is unavailable (and unnecessary, as the
+		# kernel provides idmap mounts), so the prebuilt shiftfs.ko from
+		# sysbox-flatcar-preview no longer applies.
+		if semver_lt $kversion 6.3; then
+			install_sysbox_deps_flatcar
+		else
+			echo "Skipping shiftfs installation (kernel version $kversion is above the max required for shiftfs ($shiftfs_max_kernel_ver))."
+		fi
 	else
 		if semver_ge $kversion 5.4 && semver_lt $kversion 5.8; then
 			cp -r "/opt/shiftfs-k5.4" "$host_run/shiftfs-dkms"


### PR DESCRIPTION
This is the Flatcar-specific follow-up to [#152](https://github.com/nestybox/sysbox-pkgr/pull/152) (containerd drop-in for k3s / RKE2). On a 6.x Flatcar node running RKE2, the install dies at the EE-only guard in `do_distro_adjustments()` before #152's drop-in logic gets a chance to run.

The historical reason for that guard was shiftfs being EE-exclusive (the `sysbox-flatcar-preview` build), but on 6.x:

- `sysbox-flatcar-preview` `shiftfs.ko` no longer applies (it isn't maintained for the 6.x line; module load fails).
- The kernel provides `idmap` mounts in mainline, which sysbox-runc uses transparently in place of shiftfs.

So shiftfs isn't reachable on 6.x even if you wanted it, and the alternative (`idmap`) isn't EE-restricted. This PR tries to make CE on 6.x Flatcar work:

1. Skip `install_sysbox_deps_flatcar` on kernels ≥ 6.x — the function only installs the shiftfs preview, which can't build on 6.x. Fall back to `bin/generic` artifacts.
2. Adjust the containerd drop-in `BinaryName` to `/opt/bin/sysbox-runc` on Flatcar (Flatcar's `/usr` is read-only). This piggybacks on the existing Flatcar path-rewrite sed pile in `do_distro_adjustments()`.
3. The EE-only `die` block is taken out — see the paragraph below; if the policy still applies for reasons other than shiftfs availability, this is the bullet to flag and I'll drop the change.

I don't have full context on whether the "Flatcar = EE only" policy from [PR #48 (2021-09)](https://github.com/nestybox/sysbox-pkgr/pull/48) still applies for non-shiftfs reasons (licensing, support scope, etc.). If there's something I'm missing, happy to adjust or drop the relevant parts — the verification below is just to show that the technical pieces line up.

### Verification

Tested on Flatcar 4593.2.1 + kernel 6.12.87 + RKE2 v1.36.0+rke2r1 + containerd 2.2.3-k3s1 + Cilium CNI, with stock upstream sysbox-runc master. A statically-built `fusermount3` was placed on the host at `/opt/bin/fusermount3` out-of-band (built from [Till0196/fusermount3-static](https://github.com/Till0196/fusermount3-static); see the fusermount note below for why):

| Scenario | Result |
|---|---|
| Sysbox-CE install via daemonset on Flatcar 4593+ | Success (currently dies on `die` guard) |
| `runtimeClassName: sysbox-runc` + `hostUsers: false` (alpine) | Running; sysfs/proc/sysbox-fs FUSE all functional |
| Same + docker:dind inner workload | Running; bridge net + outbound functional |
| `runtimeClassName: sysbox-runc` on EE × Flatcar 4593+ (kernel 6.x) | Continues to work (no regression for EE flow; only adds the 6.x skip branch) |

### Open items / known limitations

- `fusermount3` still needs to be reachable on the host. sysbox-fs in the v0.7.0 deb invokes `fusermount3` to set up its FUSE mounts, and Flatcar's base image doesn't ship one. Until now `install_sysbox_deps_flatcar` supplied it alongside the shiftfs preview; skipping that function on 6.x removes that path.

  For the verification above I built a statically-linked `fusermount3` ([Till0196/fusermount3-static](https://github.com/Till0196/fusermount3-static) — a small wrapper around libfuse's `util/fusermount.c` for minimal distros like Flatcar / Talos / distroless) and dropped it into `/opt/bin/` out-of-band. That's enough to make sysbox-fs work.

  One option going forward is for the daemonset to bundle a small static `fusermount3` independently of the shiftfs flow. I left it out of this PR because adding a binary the project then has to maintain feels like a maintenance-cost call that should be on your side rather than mine.

  As a separate, parallel attempt, [nestybox/fuse#10](https://github.com/nestybox/fuse/pull/10) proposes letting sysbox-fs call mount(2) directly when running as root, so the `fusermount3` binary isn't needed at all. I also ran the FUSE-touching scenarios above with a sysbox-fs built against that branch and no `fusermount3` on the host — they passed.

  If Flatcar support is going to continue, my impression is that the fuse-side route is the cheaper integration overall: a small library patch, with no extra static binary to build, ship, and keep in sync with the deb. So between the two options above, I'd softly lean toward picking up the fuse PR rather than adding a static `fusermount3` to the daemonset — but that's a judgment call from your side.
- K8s version: tested on v1.36, which is currently outside `is_supported_k8s_version`'s allowlist. Allowlist extension is tracked in nestybox/sysbox#961, separately.
